### PR TITLE
fix: Vercel 배포 환경의 이미지 렌더링 오류 수정 및 도메인 설정 최신화

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,9 +2,6 @@
 
 const nextConfig = {
   reactStrictMode: true,
-  images: {
-    domains: ["chae-dahee.github.io"],
-  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chae-dahee.github.io",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://chae-dahee.github.io/",
+  "homepage": "https://chae-dahee.vercel.app/",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/components/blog/RightSidebar.tsx
+++ b/src/components/blog/RightSidebar.tsx
@@ -2,11 +2,6 @@ import Image from "next/image";
 import { blogInfo } from "@/data/dummyData";
 
 export default function RightSidebar() {
-  const prefix =
-    process.env.NODE_ENV === "production"
-      ? "https://chae-dahee.github.io/"
-      : "";
-
   return (
     <aside className="w-80 bg-gradient-to-b from-blue-50 to-white border-l border-gray-200 p-6 overflow-y-auto sticky top-0 h-screen">
       {/* 블로그명 */}
@@ -22,7 +17,7 @@ export default function RightSidebar() {
         <div className="flex flex-col items-center">
           <div className="relative w-24 h-24 mb-4">
             <Image
-              src={`${prefix}${blogInfo.author.avatar}`}
+              src={blogInfo.author.avatar}
               alt={blogInfo.author.name}
               width={96}
               height={96}

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -2,11 +2,6 @@ import Image from "next/image";
 import Link from "next/link";
 
 export default function Header() {
-  const prefix =
-    process.env.NODE_ENV === "production"
-      ? "https://chae-dahee.github.io/"
-      : "";
-
   return (
     <header className="w-full bg-white border-b border-gray-200 shadow-sm sticky top-0 z-50">
       <div className="container mx-auto px-6 py-4">
@@ -17,7 +12,7 @@ export default function Header() {
             className="flex items-center space-x-3 hover:opacity-80 transition-opacity"
           >
             <Image
-              src={`${prefix}/chae-dahee.png`}
+              src="/chae-dahee.png"
               alt="chae-dahee"
               width={40}
               height={40}


### PR DESCRIPTION
## 📝 PR 개요
- **목적:** Vercel 배포 환경에서 발생하는 이미지 렌더링 깨짐 현상 해결 및 도메인 설정 최신화
- **배경:** 기존 GitHub Pages 기반으로 작성된 하드코딩 도메인 설정이 Vercel 환경과 충돌함

## 🎯 주요 변경 사항

### 1. 이미지 렌더링 버그 수정 (`fix`)
- **문제:** 프로덕션 빌드 시 이미지 경로에 `https://chae-dahee.github.io/` 도메인이 강제 삽입되어 외부 이미지로 오인됨
- **해결:** 하드코딩된 `prefix` 로직을 제거하고, 상대 경로(예: `/chae-dahee.png`)를 직접 사용하여 Vercel 내장 이미지 최적화 정상 작동 유도
- **수정 파일:** 
  - `src/components/common/header.tsx`
  - `src/components/blog/RightSidebar.tsx`

### 2. 프로젝트 설정 및 메타데이터 업데이트 (`chore`)
- **문제:** `package.json`의 홈페이지 주소가 구형 도메인으로 설정되어 있으며, 더 이상 외부 도메인 허용 설정이 필요하지 않음
- **해결:**
  - `package.json`의 `homepage` 속성을 `https://chae-dahee.vercel.app/`으로 수정
  - `next.config.mjs`에서 불필요해진 `images.domains` 설정 제거
- **수정 파일:** 
  - `package.json`
  - `next.config.mjs`

## 📸 스크린샷 (선택)
- (이미지가 정상 렌더링되는 Vercel 배포 화면 캡처 첨부)

## 💡 참고 사항
- 향후 신규 이미지 추가 시, 별도 prefix 없이 `/`로 시작하는 절대경로 사용 권장
