### PR TITLE
fix/refactor: 라우팅 버그 수정 및 모바일 사이드바 개선

### DIFF
--- a/src/components/common/MobileBar.tsx
+++ b/src/components/common/MobileBar.tsx
@@ -7,34 +7,40 @@ import { useRouter } from "next/router";
 export default function MobileBar() {
   const [open, setOpen] = useState(false);
   const router = useRouter();
-  const pageName = router.pathname === "/" ? "Home" : router.pathname.replace("/", "").replace(/[-_]/g, " ").toUpperCase();
+  const pageName = (() => {
+    if (router.pathname === "/") return "Home";
+    const slug = router.query.slug;
+    const resolved = slug
+      ? router.pathname.replace("[slug]", Array.isArray(slug) ? slug[0] : slug)
+      : router.pathname;
+    return resolved.replace(/^\//, "").replace(/\//g, " / ").replace(/[-_]/g, " ").toUpperCase();
+  })();
 
   return (
     <>
       {/* Top Bar - visible on md and below */}
-      <header className="md:hidden fixed top-0 left-0 right-0 bg-[var(--color-bg)] border-b border-[var(--color-surface)] z-40 flex items-center justify-between px-4 py-2">
+      <header className="md:hidden fixed top-0 left-0 right-0 z-50 bg-[var(--color-bg)] border-b border-[var(--color-surface)] flex items-center justify-between px-4 py-2">
         <Link href="/" className="flex items-center space-x-2">
           <Image src="/chae-dahee.png" alt="logo" width={32} height={32} />
           <span className="text-sm font-medium text-[var(--color-accent)]">닿망징창의 터미널</span>
         </Link>
         <span className="text-sm text-[var(--color-secondary)]">{pageName}</span>
-        <button onClick={() => setOpen(true)} className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] focus:outline-none">
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16"/></svg>
+        <button onClick={() => setOpen((v) => !v)} className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] focus:outline-none relative w-6 h-6">
+          <svg className={`w-6 h-6 absolute inset-0 transition-all duration-200 ${open ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16"/></svg>
+          <svg className={`w-6 h-6 absolute inset-0 transition-all duration-200 ${open ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/></svg>
         </button>
       </header>
 
-      {/* Drawer */}
-      {open && (
-        <div className="fixed inset-0 z-50">
-          <div className="fixed inset-0" style={{ backgroundColor: "var(--color-bg)", opacity: 0.7 }} onClick={() => setOpen(false)} />
-          <aside className="fixed top-0 left-0 w-72 h-full bg-[var(--color-bg)] shadow-lg overflow-y-auto">
-            <button onClick={() => setOpen(false)} className="absolute top-2 right-2 text-[var(--color-secondary)] hover:text-[var(--color-accent)]">
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/></svg>
-            </button>
-            <Sidebar className="block md:hidden" />
-          </aside>
-        </div>
-      )}
+      {/* Backdrop — covers content area below topbar only */}
+      <div
+        className={`md:hidden fixed top-12 inset-x-0 bottom-0 z-40 bg-black transition-opacity duration-300 ${open ? 'opacity-50 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        onClick={() => setOpen(false)}
+      />
+
+      {/* Drawer Panel — slides in from right, below topbar */}
+      <aside className={`md:hidden fixed top-12 right-0 z-40 w-64 h-[calc(100vh-3rem)] bg-[var(--color-bg)] border-l border-[var(--color-surface)] shadow-lg overflow-y-auto overflow-x-hidden transition-transform duration-300 ease-in-out ${open ? 'translate-x-0' : 'translate-x-full'}`}>
+        <Sidebar className="flex border-r-0 !h-auto !w-full !p-4 text-sm" hideLogo />
+      </aside>
     </>
   );
 }

--- a/src/components/common/MobileBar.tsx
+++ b/src/components/common/MobileBar.tsx
@@ -25,9 +25,15 @@ export default function MobileBar() {
           <span className="text-sm font-medium text-[var(--color-accent)]">닿망징창의 터미널</span>
         </Link>
         <span className="text-sm text-[var(--color-secondary)]">{pageName}</span>
-        <button onClick={() => setOpen((v) => !v)} className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] focus:outline-none relative w-6 h-6">
-          <svg className={`w-6 h-6 absolute inset-0 transition-all duration-200 ${open ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16"/></svg>
-          <svg className={`w-6 h-6 absolute inset-0 transition-all duration-200 ${open ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/></svg>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? '메뉴 닫기' : '메뉴 열기'}
+          aria-expanded={open}
+          aria-controls="mobile-drawer"
+          className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:rounded relative w-6 h-6"
+        >
+          <svg className={`w-6 h-6 absolute inset-0 transition-all duration-200 ${open ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'}`} aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16"/></svg>
+          <svg className={`w-6 h-6 absolute inset-0 transition-all duration-200 ${open ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'}`} aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/></svg>
         </button>
       </header>
 
@@ -38,7 +44,7 @@ export default function MobileBar() {
       />
 
       {/* Drawer Panel — slides in from right, below topbar */}
-      <aside className={`md:hidden fixed top-12 right-0 z-40 w-64 h-[calc(100vh-3rem)] bg-[var(--color-bg)] border-l border-[var(--color-surface)] shadow-lg overflow-y-auto overflow-x-hidden transition-transform duration-300 ease-in-out ${open ? 'translate-x-0' : 'translate-x-full'}`}>
+      <aside id="mobile-drawer" className={`md:hidden fixed top-12 right-0 z-40 w-64 h-[calc(100vh-3rem)] bg-[var(--color-bg)] border-l border-[var(--color-surface)] shadow-lg overflow-y-auto overflow-x-hidden transition-transform duration-300 ease-in-out ${open ? 'translate-x-0' : 'translate-x-full'}`}>
         <Sidebar className="flex border-r-0 !h-auto !w-full !p-4 text-sm" hideLogo />
       </aside>
     </>

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { categories, tags, sitemap, blogInfo } from "@/data/dummyData";
 
-export default function Sidebar({ className }: { className?: string }) {
+export default function Sidebar({ className, hideLogo }: { className?: string; hideLogo?: boolean }) {
   const [typedName, setTypedName] = useState("");
   const fullName = blogInfo.author.name;
 
@@ -18,13 +18,15 @@ export default function Sidebar({ className }: { className?: string }) {
   }, [fullName]);
 
   return (
-    <aside className={`hidden md:flex flex-col w-72 bg-[var(--color-bg)] border-r border-[var(--color-surface)] sticky top-0 h-screen overflow-y-auto p-6 ${className ?? ''}`}>
+    <aside className={`flex flex-col w-72 bg-[var(--color-bg)] border-r border-[var(--color-surface)] sticky top-0 h-screen overflow-y-auto p-6 ${className ?? ''}`}>
 
       {/* Logo + Site name */}
-      <div className="flex items-center mb-8">
-        <Image src="/chae-dahee.png" alt="logo" width={40} height={40} />
-        <h1 className="ml-2 text-xl font-bold text-[var(--color-accent)]">닿망징창의 터미널</h1>
-      </div>
+      {!hideLogo && (
+        <div className="flex items-center mb-8">
+          <Image src="/chae-dahee.png" alt="logo" width={40} height={40} />
+          <h1 className="ml-2 text-xl font-bold text-[var(--color-accent)]">닿망징창의 터미널</h1>
+        </div>
+      )}
 
       {/* Profile */}
       <div className="mb-8 text-center">

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -43,19 +43,19 @@ export default function Header() {
               Home
             </Link>
             <Link
-              href="/#categories"
+              href="/category"
               className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors"
             >
               Categories
             </Link>
             <Link
-              href="/#tags"
+              href="/tag"
               className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors"
             >
               Tags
             </Link>
             <Link
-              href="/#about"
+              href="/about"
               className="text-[var(--color-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors"
             >
               About

--- a/src/components/common/layout.tsx
+++ b/src/components/common/layout.tsx
@@ -11,7 +11,7 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <div className="flex min-h-screen bg-[var(--color-bg)]">
       {/* Desktop Sidebar */}
-      <Sidebar className="hidden md:block" />
+      <Sidebar className="hidden md:flex" />
 
       {/* Mobile Top Bar */}
       <MobileBar />

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -10,7 +10,7 @@ export default function Blog() {
         <ul className="space-y-6">
           {posts.map((post) => (
             <li key={post.id} className="bg-[var(--color-surface)] p-4 hover:bg-[var(--color-muted)] transition">
-              <Link href={`/blog/${post.slug}`} className="text-xl font-medium text-[var(--color-accent)] hover:underline">
+              <Link href={`/posts/${post.slug}`} className="text-xl font-medium text-[var(--color-accent)] hover:underline">
                 {post.title}
               </Link>
               <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>

--- a/src/pages/category/[slug].tsx
+++ b/src/pages/category/[slug].tsx
@@ -1,10 +1,13 @@
 import Layout from '@/components/common/layout';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { categories, posts } from '@/data/dummyData';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 
-export default function CategoryPage() {
-  const { slug } = useRouter().query as { slug: string };
+interface CategoryPageProps {
+  slug: string;
+}
+
+export default function CategoryPage({ slug }: CategoryPageProps) {
   const category = categories.find((c) => c.slug === slug);
   const filteredPosts = posts.filter((p) => p.categorySlug === slug);
 
@@ -25,7 +28,7 @@ export default function CategoryPage() {
         <ul className="space-y-6">
           {filteredPosts.map((post) => (
             <li key={post.id} className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition">
-              <Link href={`/blog/${post.slug}`} className="text-xl font-medium text-[var(--color-accent)] hover:underline">
+              <Link href={`/posts/${post.slug}`} className="text-xl font-medium text-[var(--color-accent)] hover:underline">
                 {post.title}
               </Link>
               <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>
@@ -36,3 +39,12 @@ export default function CategoryPage() {
     </Layout>
   );
 }
+
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: categories.map((c) => ({ params: { slug: c.slug } })),
+  fallback: false,
+});
+
+export const getStaticProps: GetStaticProps<CategoryPageProps> = async ({ params }) => ({
+  props: { slug: params?.slug as string },
+});

--- a/src/pages/tag/[slug].tsx
+++ b/src/pages/tag/[slug].tsx
@@ -1,14 +1,13 @@
 import Layout from '@/components/common/layout';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { tags, posts } from '@/data/dummyData';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 
-export default function TagPage() {
-  const { slug } = useRouter().query as { slug: string };
+interface TagPageProps {
+  slug: string;
+}
 
-  if (!slug) return null;
-
-  const tagName = slug.replace(/-/g, ' ');
+export default function TagPage({ slug }: TagPageProps) {
   const tag = tags.find((t) => t.name.toLowerCase() === slug.toLowerCase());
   const filteredPosts = posts.filter((p) => p.tags.map((t) => t.toLowerCase()).includes(slug.toLowerCase()));
 
@@ -29,7 +28,7 @@ export default function TagPage() {
         <ul className="space-y-6">
           {filteredPosts.map((post) => (
             <li key={post.id} className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition">
-              <Link href={`/blog/${post.slug}`} className="text-xl font-medium text-[var(--color-accent)] hover:underline">
+              <Link href={`/posts/${post.slug}`} className="text-xl font-medium text-[var(--color-accent)] hover:underline">
                 {post.title}
               </Link>
               <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>
@@ -40,3 +39,12 @@ export default function TagPage() {
     </Layout>
   );
 }
+
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: tags.map((t) => ({ params: { slug: t.name.toLowerCase() } })),
+  fallback: false,
+});
+
+export const getStaticProps: GetStaticProps<TagPageProps> = async ({ params }) => ({
+  props: { slug: params?.slug as string },
+});


### PR DESCRIPTION
## 배경 및 목적

- Vercel 빌드 시 `tag/[slug]` 프리렌더 에러 → 빌드 실패
- `blog`, `tag`, `category` 포스트 링크가 `/blog/${slug}` 참조 → 실제 라우트 `/posts/[slug]`와 불일치로 404
- 헤더 네비게이션이 존재하지 않는 홈 앵커(`/#categories` 등) 참조 → 이동 실패
- 모바일 사이드바 z-index 미설정 → 카드 요소에 가려짐
- 동적 라우트 페이지명 `[SLUG]`로 표시

## 설계

- `tag/[slug]`, `category/[slug]`의 slug를 `useRouter().query`(클라이언트)에서 읽는 방식은 프리렌더 시점에 `router.query === {}`이므로 구조적으로 런타임 에러 불가피
- 기존 `posts/[slug]`에서 사용 중인 `getStaticPaths` + `getStaticProps` 패턴으로 통일 → slug를 빌드 타임 props로 주입
- 프로젝트 내 동적 라우트 패턴 일관성 확보 및 빌드 타임 HTML 생성으로 SEO 개선

## 구현 내용

- `src/pages/tag/[slug].tsx` — `useRouter` 제거, `getStaticPaths`/`getStaticProps` 전환, 포스트 링크 `/posts`로 수정
- `src/pages/category/[slug].tsx` — 동일
- `src/pages/blog/index.tsx` — 포스트 링크 `/blog` → `/posts`
- `src/components/common/header.tsx` — `/#categories` → `/category`, `/#tags` → `/tag`, `/#about` → `/about`
- `src/components/common/MobileBar.tsx` — z-index 추가(header `z-50`, backdrop/aside `z-40`), 페이지명 slug 치환 로직 수정, 드로어 슬라이드 패널 전환
- `src/components/common/Sidebar.tsx` — `hid
- `src/components/common/layout.tsx` — Sideb로 수정

## 코드 리뷰 포인트

- `getStaticPaths`는 현재 `dummyData` 기준으로 경로 생성 → 추후 CMS/DB 연동 시 해당 부분만 교체
- MobileBar `pageName`은 hydration 이후 `rou기 SSR HTML에서 `[SLUG]` 잠깐 노출 가능 →모바일 전용 컴포넌트로 허용 범위로 판단

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `npm run build` 정상 완료 — 30개 페이지 생성, 에러 없음
- `tag/[slug]`, `category/[slug]` 빌드 타입

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모바일 메뉴 버튼 열림/닫힘 토글 및 전환 아이콘 적용
  * 모바일 상단 페이지명 표기 개선(동적 라우트 값 기반 해석)

* **개선사항**
  * 네비게이션 링크 및 포스트 경로 통일(카테고리/태그/블로그 이동 경로 정비)
  * 카테고리·태그 페이지를 정적 생성(SSG) 방식으로 전환해 페이지 로딩 성능 개선
  * 모바일 드로어 전환(백드롭/패널 애니메이션) 및 사이드바 레이아웃 동작 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->