### PR TITLE
fix: 모바일 드로어 열림 시 배경 스크롤 잠금

### DIFF
--- a/src/components/common/MobileBar.tsx
+++ b/src/components/common/MobileBar.tsx
@@ -9,8 +9,12 @@ export default function MobileBar() {
   const router = useRouter();
 
   useEffect(() => {
-    document.body.style.overflow = open ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
+    if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
   }, [open]);
   
   const pageName = (() => {

--- a/src/components/common/MobileBar.tsx
+++ b/src/components/common/MobileBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Sidebar from "@/components/common/Sidebar";
 import Image from "next/image";
 import Link from "next/link";
@@ -7,6 +7,12 @@ import { useRouter } from "next/router";
 export default function MobileBar() {
   const [open, setOpen] = useState(false);
   const router = useRouter();
+
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : '';
+    return () => { document.body.style.overflow = ''; };
+  }, [open]);
+  
   const pageName = (() => {
     if (router.pathname === "/") return "Home";
     const slug = router.query.slug;
@@ -39,7 +45,7 @@ export default function MobileBar() {
 
       {/* Backdrop — covers content area below topbar only */}
       <div
-        className={`md:hidden fixed top-12 inset-x-0 bottom-0 z-40 bg-black transition-opacity duration-300 ${open ? 'opacity-50 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        className={`md:hidden fixed top-12 inset-x-0 bottom-0 z-40 bg-black transition-opacity duration-300 ${open ? 'opacity-50 pointer-events-auto touch-none' : 'opacity-0 pointer-events-none'}`}
         onClick={() => setOpen(false)}
       />
 


### PR DESCRIPTION
## 배경 및 목적

- 모바일에서 햄버거 드로어가 열린 상태에서 배경 화면이 세로로 스크롤되는 문제
- backdrop의 `pointer-events-auto`로 탭은 차단되나, 터치 드래그 제스처가 body로 전파(scroll chaining)되어 배경이 스크롤됨

## 설계

- 1차 시도였던 `touch-none`(`touch-action: none`)은 backdrop이 스크롤 요소가 아니라 iOS Safari 등에서 배경 스크롤을 
- CSS만으로 해결 불가능한 케이스이므로 `useEffect`로 처리, cleanup에서 원복

## 구현 내용

- `src/components/common/MobileBar.tsx`
  - `useEffect`로 `open` 상태에 따라 `body` overflow 잠금/복원 추가
  - backdrop에 `touch-none` 추가 (제스처 흡수 보조)

## 코드 리뷰 포인트

- `useEffect` cleanup으로 드로어 닫힘·언마운트 시 `body.style.overflow` 복원 → 스크롤 잠금 잔존 없음
- backdrop `touch-none` + body 잠금 2중 방어 구조

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- 모바일 뷰포트에서 드로어 열림 시 배경 스크롤 차단 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 모바일 메뉴가 열릴 때 페이지 배경 스크롤이 더 이상 되지 않도록 개선
  * 백드롭 오버레이의 터치 상호작용이 열린 상태에서 비활성화되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->