### PR TITLE
refactor: 포스트 상세 라우트를 /blog/[slug]로 표준화

### DIFF
--- a/src/app/(main)/blog/[slug]/page.tsx
+++ b/src/app/(main)/blog/[slug]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({
   return buildMetadata({
     title: post.title,
     description: post.excerpt,
-    url: `/posts/${post.slug}`,
+    url: `/blog/${post.slug}`,
     image: post.image,
     type: "article",
     publishedTime: `${post.date}T00:00:00+09:00`,

--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -19,7 +19,7 @@ export default function Blog() {
             className="bg-[var(--color-surface)] p-4 hover:bg-[var(--color-muted)] transition"
           >
             <Link
-              href={`/posts/${post.slug}`}
+              href={`/blog/${post.slug}`}
               className="text-xl font-medium text-[var(--color-accent)] hover:underline"
             >
               {post.title}

--- a/src/app/(main)/category/[slug]/page.tsx
+++ b/src/app/(main)/category/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function CategoryPage({
             className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
           >
             <Link
-              href={`/posts/${post.slug}`}
+              href={`/blog/${post.slug}`}
               className="text-xl font-medium text-[var(--color-accent)] hover:underline"
             >
               {post.title}

--- a/src/app/(main)/tag/[slug]/page.tsx
+++ b/src/app/(main)/tag/[slug]/page.tsx
@@ -47,7 +47,7 @@ export default async function TagPage({
             className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
           >
             <Link
-              href={`/posts/${post.slug}`}
+              href={`/blog/${post.slug}`}
               className="text-xl font-medium text-[var(--color-accent)] hover:underline"
             >
               {post.title}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -17,7 +17,7 @@ function generateRssFeed(): string {
 
     ${posts
       .map((post) => {
-        const postUrl = `${baseUrl}/posts/${post.slug}`;
+        const postUrl = `${baseUrl}/blog/${post.slug}`;
         const pubDate = new Date(post.date).toUTCString();
         return `<item>
       <title><![CDATA[${post.title}]]></title>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,7 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   ];
 
   const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `${baseUrl}/posts/${post.slug}`,
+    url: `${baseUrl}/blog/${post.slug}`,
     lastModified: new Date(`${post.date}T00:00:00+09:00`),
   }));
 

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -226,7 +226,7 @@ export default function PostDetail({ post }: PostDetailProps) {
       <div className="mt-16 pt-8 border-t border-[var(--color-muted)]">
         <div className="grid md:grid-cols-2 gap-4">
           <Link
-            href="/posts/prev"
+            href="/blog/prev"
             className="flex items-center p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
           >
             <svg
@@ -250,7 +250,7 @@ export default function PostDetail({ post }: PostDetailProps) {
             </div>
           </Link>
           <Link
-            href="/posts/next"
+            href="/blog/next"
             className="flex items-center justify-end p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
           >
             <div className="text-right">

--- a/src/components/blog/PostList.tsx
+++ b/src/components/blog/PostList.tsx
@@ -21,7 +21,7 @@ export default function PostList({ posts }: PostListProps) {
             key={post.id}
             className="bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-all duration-300 overflow-hidden group cursor-pointer"
           >
-            <Link href={`/posts/${post.slug}`} className="block">
+            <Link href={`/blog/${post.slug}`} className="block">
               {/* 이미지 영역 */}
               <div className="relative h-48 bg-[var(--color-bg)] border-b border-[var(--color-muted)] overflow-hidden">
                 <div className="absolute inset-0 flex items-center justify-center text-[var(--color-accent)]/20 text-6xl font-bold">


### PR DESCRIPTION
## 배경 및 목적

- App Router 표준 컨벤션상 목록과 상세는 한 세그먼트를 공유해야 함
- 기존 구조: 목록 `/blog` ↔ 상세 `/posts/[slug]`로 세그먼트가 어긋남
- 운영 전 구현 단계라 SEO·링크를 표준에 맞춰 정리 가능 → 상세를 `/blog/[slug]`로 통일

## 설계

- 상세 라우트 세그먼트를 `posts/[slug]` → `blog/[slug]`로 이동해 목록 `/blog`과 통일
- `/posts/` 참조(내부 링크 + `sitemap`/RSS canonical)를 모두 `/blog/`로 갱신
- 기능별 커밋 분리: 라우트 이동 / 내부 링크 / SEO·피드
- 패딩·레이아웃 정리는 별도 PR(#17, 머지 완료) 소관 → 본 PR은 라우팅만 포함

## 구현 내용

- **`refactor: 포스트 상세 라우트를 posts/[slug]에서 blog/[slug]로 이동`** (`f508189`)
  - `(main)/posts/[slug]/page.tsx` → `(main)/blog/[slug]/page.tsx` (rename 96%), 자체 canonical `url` 갱신
- **`refactor: 포스트 링크 경로를 /blog/[slug]로 갱신`** (`1faff3a`)
  - `blog/page` / `category/[slug]` / `tag/[slug]` / `PostList` / `PostDetail`(prev·next) 내부 링크
- **`refactor: sitemap·RSS의 포스트 URL을 /blog/[slug]로 갱신`** (`fcf3859`)
  - `sitemap.ts`, `rss.xml/route.ts` canonical

## 코드 리뷰 포인트

- 운영 전 단계라 redirect 불필요 — 기존 `/posts/[slug]` URL은 폐기
- `PostDetail`의 `/blog/prev`·`/blog/next`는 더미 링크(이전·다음 로직 미구현) → 별도 과제
- 이 브랜치 base(`55820c1`)는 #17 머지된 `main` 계보와 동일 → `main` 대상 PR 시 diff는 라우팅 3커밋만 표시

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 — 운영 전 단계, 외부 노출 URL 이력 없음. `/posts/` 참조 0건 확인
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리 — 해당 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음 — `sitemap`/RSS는 새 URL로 정상 생성

## 테스트

- `npm run build` 통과 — 정적 33페이지, `/blog/[slug]` 8개 생성(`/posts/[slug]` 소멸)
- `tsc --noEmit` 통과

- 이 문서는 화면에만 표시했고 파일 생성·PR 생성은 하지 않았습니다.
- push/PR 생성을 원하시면 말씀해 주십시오. 그대로 진행하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 블로그 게시물 URL 경로를 `/posts/`에서 `/blog/`로 통일했습니다. 블로그 목록, 카테고리, 태그 페이지 및 RSS 피드의 게시물 링크가 새로운 경로를 반영하도록 업데이트되었습니다. 또한 사이트맵과 게시물 내비게이션 링크도 함께 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->