### PR TITLE
style: 사이드바의 좌측 불필요한 ml 을 제거한다.

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -26,7 +26,7 @@ export default function Sidebar({ className, hideLogo }: { className?: string; h
       {/* Logo + Site name */}
       {!hideLogo && (
         <div className="flex items-center justify-between mb-8">
-          <h1 className="ml-2 text-xl font-bold text-[var(--color-accent)]">닿망징창의 터미널</h1>
+          <h1 className="text-xl font-bold text-[var(--color-accent)]">닿망징창의 터미널</h1>
           <ThemeToggle />
         </div>
       )}


### PR DESCRIPTION
## 배경 및 목적

제거한 프로필이미지에 따라 좌측 ml 이 불필요하여 제거한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* 사이드바의 로고 영역 좌측 여백을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->