### PR TITLE
fix: 모바일 반응형 개선 및 포스트 카드 통일

### DIFF
--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -11,20 +11,40 @@ export const metadata: Metadata = buildMetadata({
 export default function Blog() {
   return (
     <section className="max-w-4xl mx-auto">
-      <h1 className="text-4xl font-bold mb-8 text-[var(--color-accent)]">Blog</h1>
-      <ul className="space-y-6">
+      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-6 md:mb-8 text-[var(--color-accent)]">
+        Blog
+      </h1>
+      <ul className="space-y-4">
         {posts.map((post) => (
-          <li
-            key={post.id}
-            className="bg-[var(--color-surface)] p-4 hover:bg-[var(--color-muted)] transition"
-          >
+          <li key={post.id}>
             <Link
               href={`/blog/${post.slug}`}
-              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
+              className="flex bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors overflow-hidden group"
             >
-              {post.title}
+              {/* 이미지 영역 (좌측 ~28%) */}
+              <div className="relative w-[28%] sm:w-[25%] flex-shrink-0 bg-[var(--color-bg)] border-r border-[var(--color-muted)] flex items-center justify-center overflow-hidden">
+                <span className="text-3xl sm:text-5xl font-bold text-[var(--color-accent)]/20">
+                  {post.id}
+                </span>
+                <span className="absolute top-2 left-2 bg-[var(--color-surface)] border border-[var(--color-accent)] px-1.5 py-0.5 text-[10px] sm:text-xs font-semibold text-[var(--color-accent)]">
+                  {post.category}
+                </span>
+              </div>
+
+              {/* 글 영역 (우측) */}
+              <div className="flex-1 min-w-0 p-3 sm:p-4">
+                <div className="flex items-center text-[10px] sm:text-xs text-[var(--color-secondary)] mb-1.5 gap-x-3">
+                  <span>{post.date}</span>
+                  <span>{post.readTime}분 읽기</span>
+                </div>
+                <h2 className="text-base sm:text-lg md:text-xl font-bold text-[var(--color-accent)] line-clamp-1 sm:line-clamp-2">
+                  {post.title}
+                </h2>
+                <p className="mt-1 text-xs sm:text-sm text-[var(--color-secondary)] line-clamp-2">
+                  {post.excerpt}
+                </p>
+              </div>
             </Link>
-            <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>
           </li>
         ))}
       </ul>

--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { posts } from "@/data/dummyData";
+import PostCard from "@/components/blog/PostCard";
 import { buildMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
 
@@ -17,34 +17,7 @@ export default function Blog() {
       <ul className="space-y-4">
         {posts.map((post) => (
           <li key={post.id}>
-            <Link
-              href={`/blog/${post.slug}`}
-              className="flex bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors overflow-hidden group"
-            >
-              {/* 이미지 영역 (좌측 ~28%) */}
-              <div className="relative w-[28%] sm:w-[25%] flex-shrink-0 bg-[var(--color-bg)] border-r border-[var(--color-muted)] flex items-center justify-center overflow-hidden">
-                <span className="text-3xl sm:text-5xl font-bold text-[var(--color-accent)]/20">
-                  {post.id}
-                </span>
-                <span className="absolute top-2 left-2 bg-[var(--color-surface)] border border-[var(--color-accent)] px-1.5 py-0.5 text-[10px] sm:text-xs font-semibold text-[var(--color-accent)]">
-                  {post.category}
-                </span>
-              </div>
-
-              {/* 글 영역 (우측) */}
-              <div className="flex-1 min-w-0 p-3 sm:p-4">
-                <div className="flex items-center text-[10px] sm:text-xs text-[var(--color-secondary)] mb-1.5 gap-x-3">
-                  <span>{post.date}</span>
-                  <span>{post.readTime}분 읽기</span>
-                </div>
-                <h2 className="text-base sm:text-lg md:text-xl font-bold text-[var(--color-accent)] line-clamp-1 sm:line-clamp-2">
-                  {post.title}
-                </h2>
-                <p className="mt-1 text-xs sm:text-sm text-[var(--color-secondary)] line-clamp-2">
-                  {post.excerpt}
-                </p>
-              </div>
-            </Link>
+            <PostCard post={post} />
           </li>
         ))}
       </ul>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -12,7 +12,7 @@ export default function MainLayout({
       <Sidebar className="hidden md:flex" />
       <MobileBar />
       <div className="flex-1 flex flex-col">
-        <main className="flex-1 p-8 pt-20 md:p-10 md:pt-10">
+        <main className="flex-1 p-4 pt-20 md:p-10 md:pt-10">
           {children}
         </main>
         <Footer />

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -9,7 +9,7 @@ export default function PostCard({ post }: PostCardProps) {
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className="flex bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors overflow-hidden group"
+      className="flex bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors overflow-hidden group"
     >
       {/* 이미지 영역 (좌측 ~28%) */}
       <div className="relative w-[28%] sm:w-[25%] flex-shrink-0 bg-[var(--color-bg)] border-r border-[var(--color-muted)] flex items-center justify-center overflow-hidden">

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import type { Post } from "@/types";
+
+interface PostCardProps {
+  post: Post;
+}
+
+export default function PostCard({ post }: PostCardProps) {
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="flex bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors overflow-hidden group"
+    >
+      {/* 이미지 영역 (좌측 ~28%) */}
+      <div className="relative w-[28%] sm:w-[25%] flex-shrink-0 bg-[var(--color-bg)] border-r border-[var(--color-muted)] flex items-center justify-center overflow-hidden">
+        <span className="text-3xl sm:text-5xl font-bold text-[var(--color-accent)]/20">
+          {post.id}
+        </span>
+      </div>
+
+      {/* 글 영역 (우측) */}
+      <div className="flex-1 min-w-0 p-3 sm:p-4">
+        <div className="flex items-center text-[10px] sm:text-xs text-[var(--color-secondary)] mb-1.5 gap-x-3">
+          <span>{post.date}</span>
+          <span>{post.readTime}분 읽기</span>
+          <span>{post.category}</span>
+        </div>
+        <h2 className="text-base sm:text-lg md:text-xl font-bold text-[var(--color-accent)] line-clamp-1 sm:line-clamp-2">
+          {post.title}
+        </h2>
+        <p className="mt-1 text-xs sm:text-sm text-[var(--color-secondary)] line-clamp-2">
+          {post.excerpt}
+        </p>
+        <div className="hidden sm:flex flex-wrap gap-2 mt-3">
+          {post.tags.slice(0, 3).map((tag, index) => (
+            <span
+              key={index}
+              className="inline-block px-2 py-0.5 text-xs font-medium text-[var(--color-accent)] bg-[var(--color-bg)] border border-[var(--color-accent)]/30"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -23,7 +23,7 @@ export default function PostDetail({ post }: PostDetailProps) {
   return (
     <div className="max-w-5xl mx-auto">
       {/* 헤더 */}
-      <header className="mb-8 pb-8 border-b border-[var(--color-muted)]">
+      <header className="mb-6 pb-6 md:mb-8 md:pb-8 border-b border-[var(--color-muted)]">
         <div className="mb-4">
           <Link
             href={`/category/${post.categorySlug}`}
@@ -33,14 +33,14 @@ export default function PostDetail({ post }: PostDetailProps) {
           </Link>
         </div>
 
-        <h1 className="text-4xl md:text-5xl font-bold text-[var(--color-accent)] mb-4 leading-tight">
+        <h1 className="text-2xl sm:text-3xl md:text-5xl font-bold text-[var(--color-accent)] mb-3 md:mb-4 leading-tight">
           {post.title}
         </h1>
 
-        <div className="flex items-center text-[var(--color-secondary)] space-x-6">
+        <div className="flex flex-wrap items-center text-xs sm:text-sm md:text-base text-[var(--color-secondary)] gap-x-3 gap-y-1 sm:gap-x-4 md:gap-x-6">
           <span className="flex items-center">
             <svg
-              className="w-5 h-5 mr-2"
+              className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -56,7 +56,7 @@ export default function PostDetail({ post }: PostDetailProps) {
           </span>
           <span className="flex items-center">
             <svg
-              className="w-5 h-5 mr-2"
+              className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -72,7 +72,7 @@ export default function PostDetail({ post }: PostDetailProps) {
           </span>
           <span className="flex items-center">
             <svg
-              className="w-5 h-5 mr-2"
+              className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -130,7 +130,7 @@ export default function PostDetail({ post }: PostDetailProps) {
             <div className="flex gap-4">
               <button className="flex items-center px-4 py-2 bg-[var(--color-surface)] border border-[var(--color-accent)] text-[var(--color-accent)] hover:bg-[var(--color-muted)] transition-colors">
                 <svg
-                  className="w-5 h-5 mr-2"
+                  className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -146,7 +146,7 @@ export default function PostDetail({ post }: PostDetailProps) {
               </button>
               <button className="flex items-center px-4 py-2 bg-[var(--color-surface)] border border-[var(--color-muted)] text-[var(--color-secondary)] hover:bg-[var(--color-muted)] transition-colors">
                 <svg
-                  className="w-5 h-5 mr-2"
+                  className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -170,7 +170,7 @@ export default function PostDetail({ post }: PostDetailProps) {
             <div className="bg-[var(--color-bg)] border border-[var(--color-surface)] p-5">
               <h3 className="text-lg font-bold text-[var(--color-accent)] mb-4 flex items-center">
                 <svg
-                  className="w-5 h-5 mr-2"
+                  className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -224,13 +224,13 @@ export default function PostDetail({ post }: PostDetailProps) {
 
       {/* 이전/다음 포스트 네비게이션 */}
       <div className="mt-16 pt-8 border-t border-[var(--color-muted)]">
-        <div className="grid md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-2 sm:gap-4">
           <Link
             href="/blog/prev"
-            className="flex items-center p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
+            className="flex items-center p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
           >
             <svg
-              className="w-6 h-6 mr-3 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
+              className="w-5 h-5 mr-2 sm:w-6 sm:h-6 sm:mr-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -242,25 +242,25 @@ export default function PostDetail({ post }: PostDetailProps) {
                 d="M15 19l-7-7 7-7"
               />
             </svg>
-            <div>
+            <div className="min-w-0">
               <div className="text-xs text-[var(--color-secondary)] mb-1">이전 글</div>
-              <div className="font-semibold text-[var(--color-accent)]">
+              <div className="text-sm sm:text-base font-semibold text-[var(--color-accent)] truncate">
                 이전 포스트 제목
               </div>
             </div>
           </Link>
           <Link
             href="/blog/next"
-            className="flex items-center justify-end p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
+            className="flex items-center justify-end p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
           >
-            <div className="text-right">
+            <div className="min-w-0 text-right">
               <div className="text-xs text-[var(--color-secondary)] mb-1">다음 글</div>
-              <div className="font-semibold text-[var(--color-accent)]">
+              <div className="text-sm sm:text-base font-semibold text-[var(--color-accent)] truncate">
                 다음 포스트 제목
               </div>
             </div>
             <svg
-              className="w-6 h-6 ml-3 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
+              className="w-5 h-5 ml-2 sm:w-6 sm:h-6 sm:ml-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -227,7 +227,7 @@ export default function PostDetail({ post }: PostDetailProps) {
         <div className="grid grid-cols-2 gap-2 sm:gap-4">
           <Link
             href="/blog/prev"
-            className="flex items-center p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
+            className="flex items-center p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors group"
           >
             <svg
               className="w-5 h-5 mr-2 sm:w-6 sm:h-6 sm:mr-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
@@ -251,7 +251,7 @@ export default function PostDetail({ post }: PostDetailProps) {
           </Link>
           <Link
             href="/blog/next"
-            className="flex items-center justify-end p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-colors group"
+            className="flex items-center justify-end p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors group"
           >
             <div className="min-w-0 text-right">
               <div className="text-xs text-[var(--color-secondary)] mb-1">다음 글</div>

--- a/src/components/blog/PostList.tsx
+++ b/src/components/blog/PostList.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Post } from "@/types";
+import PostCard from "@/components/blog/PostCard";
 
 interface PostListProps {
   posts: Post[];
@@ -15,99 +16,9 @@ export default function PostList({ posts }: PostListProps) {
         </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div className="space-y-4">
         {posts.map((post) => (
-          <article
-            key={post.id}
-            className="bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] transition-all duration-300 overflow-hidden group cursor-pointer"
-          >
-            <Link href={`/blog/${post.slug}`} className="block">
-              {/* 이미지 영역 */}
-              <div className="relative h-48 bg-[var(--color-bg)] border-b border-[var(--color-muted)] overflow-hidden">
-                <div className="absolute inset-0 flex items-center justify-center text-[var(--color-accent)]/20 text-6xl font-bold">
-                  {post.id}
-                </div>
-                <div className="absolute top-4 right-4 bg-[var(--color-surface)] border border-[var(--color-accent)] px-3 py-1 text-xs font-semibold text-[var(--color-accent)]">
-                  {post.category}
-                </div>
-              </div>
-
-              {/* 콘텐츠 영역 */}
-              <div className="p-6">
-                <div className="flex items-center text-xs text-[var(--color-secondary)] mb-3 space-x-4">
-                  <span className="flex items-center">
-                    <svg
-                      className="w-4 h-4 mr-1"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                      />
-                    </svg>
-                    {post.date}
-                  </span>
-                  <span className="flex items-center">
-                    <svg
-                      className="w-4 h-4 mr-1"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    {post.readTime}분
-                  </span>
-                </div>
-
-                <h2 className="text-lg sm:text-xl font-bold text-[var(--color-accent)] mb-3 group-hover:text-[var(--color-accent)] transition-colors line-clamp-2">
-                  {post.title}
-                </h2>
-
-                <p className="text-[var(--color-secondary)] text-sm mb-4 line-clamp-3">
-                  {post.excerpt}
-                </p>
-
-                {/* 태그 */}
-                <div className="flex flex-wrap gap-2 mb-4">
-                  {post.tags.slice(0, 3).map((tag, index) => (
-                    <span
-                      key={index}
-                      className="inline-block px-2 py-1 text-xs font-medium text-[var(--color-accent)] bg-[var(--color-bg)] border border-[var(--color-accent)]/30"
-                    >
-                      #{tag}
-                    </span>
-                  ))}
-                </div>
-
-                <div className="flex items-center text-[var(--color-accent)] font-medium text-sm group-hover:translate-x-2 transition-transform">
-                  자세히 보기
-                  <svg
-                    className="w-4 h-4 ml-1"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </Link>
-          </article>
+          <PostCard key={post.id} post={post} />
         ))}
       </div>
 

--- a/src/components/blog/PostList.tsx
+++ b/src/components/blog/PostList.tsx
@@ -9,7 +9,7 @@ export default function PostList({ posts }: PostListProps) {
   return (
     <div className="max-w-full mx-auto">
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-[var(--color-accent)] mb-2">최근 포스트</h1>
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-[var(--color-accent)] mb-2">최근 포스트</h1>
         <p className="text-[var(--color-secondary)]">
           프론트엔드 개발과 관련된 다양한 주제를 다룹니다
         </p>
@@ -69,7 +69,7 @@ export default function PostList({ posts }: PostListProps) {
                   </span>
                 </div>
 
-                <h2 className="text-xl font-bold text-[var(--color-accent)] mb-3 group-hover:text-[var(--color-accent)] transition-colors line-clamp-2">
+                <h2 className="text-lg sm:text-xl font-bold text-[var(--color-accent)] mb-3 group-hover:text-[var(--color-accent)] transition-colors line-clamp-2">
                   {post.title}
                 </h2>
 


### PR DESCRIPTION
## 배경 및 목적

모바일 화면에서 다음 레이아웃 문제가 있었습니다.

- 블로그 상세: 제목(`text-4xl`)이 과대해 화면 절반 이상을 점유, 본문 패딩(`p-8`)이 모바일에서도 동일해 여백 과다, 메타(날짜·읽기·뷰)가 줄바꿈, 이전/다음 네비가 세로로 적층되고 크기가 큼.
- 홈·블로그 리스트: 제목 글자 크기가 고정이라 모바일에서 과대.

또한 홈과 `/blog`의 포스트 목록 UI가 서로 달라(홈은 세로 그리드 카드, `/blog`는 단순 텍스트 리스트) 통일이 필요했습니다.

목적: 모바일 글자 크기·여백을 반응형으로 정리하고, 포스트 목록을 한 화면에 여러 글이 보이는 가로 이미지 카드로 통일합니다.

## 설계

- **반응형 글자 크기**: 고정 `text-4xl` 등을 `text-2xl sm:text-3xl md:5xl`처럼 단계화해 모바일 과대 해소. 모든 컴포넌트가 `var(--color-*)`만 쓰므로 색상은 그대로 두고 크기·여백만 조정.
- **가로 이미지 카드 통일**: 홈·`/blog`가 공유하는 `PostCard` 컴포넌트를 추출(좌측 ~28% 이미지 영역 / 우측 글 영역). 두 화면이 갈라지지 않도록 단일 컴포넌트로 수렴.
  - `post.image` 경로의 실제 파일이 없어, 기존 방식대로 `post.id` 숫자 플레이스홀더로 이미지 영역 구성(깨진 이미지 방지).
  - 카테고리는 이미지 배지 대신 메타 행 `readTime` 우측에 동일 형식(텍스트)으로 표시.
  - 모바일에서는 태그를 숨겨(`sm` 이상 노출) 카드 높이를 줄이고 한 화면 노출 글 수를 늘림.
- **이전/다음 네비**: 모바일 1열 적층 → 반반 2열(`grid-cols-2`)로 고정, 제목 `truncate`로 줄바꿈 방지.

## 구현 내용

- `src/app/(main)/layout.tsx`: 본문 패딩 `p-8` → `p-4`(md 이상 `p-10` 유지).
- `src/components/blog/PostDetail.tsx`: 제목·헤더 여백·메타(글자/아이콘/간격) 반응형, 이전/다음 네비 반반 2열·축소·`truncate`.
- `src/components/blog/PostCard.tsx` (신규): 가로 이미지 카드 공통 컴포넌트.
- `src/components/blog/PostList.tsx`(홈): 그리드 카드 → `PostCard` 목록, 제목 반응형.
- `src/app/(main)/blog/page.tsx`: 단순 리스트 → `PostCard` 목록, 제목 반응형.

## 코드 리뷰 포인트

- `PostCard`로 홈·`/blog` 카드 마크업이 단일화됨 — 한쪽만 바꾸면 양쪽에 반영되는 점 인지 필요.
- 이미지 영역은 실제 이미지가 아니라 `post.id` 플레이스홀더(실제 `post.image` 파일 부재). 추후 실제 이미지 도입 시 `PostCard`만 수정하면 됨.
- 메타 행은 `flex-wrap`이라 매우 좁은 화면에서 줄바꿈은 허용(가독성 우선).

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 (라우팅·링크 경로 변경 없음, 시각/레이아웃 조정에 한정)
- [x] 외부 파일·설정 수정 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- ESLint·`tsc --noEmit` 통과.
- 모바일/데스크톱에서 홈·`/blog`·상세 페이지 레이아웃은 dev 서버 수동 확인 권장.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩터**
  * 블로그 목록의 포스트 카드가 컴포넌트 기반으로 정리되어, 포스트 표시 방식이 더 일관되게 개선되었습니다.

* **스타일**
  * 블로그 페이지 제목 크기/여백과 목록 간격이 조정되었습니다.
  * 메인 레이아웃의 기본 패딩이 줄어들어 화면이 더 효율적으로 보이도록 변경되었습니다.
  * 포스트 상세 화면의 모바일 타이포그래피와 메타/아이콘 간격이 더 촘촘해졌습니다.
  * 이전/다음 네비게이션 레이아웃과 제목 표시가 더 깔끔하게 다듬어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->