### PR TITLE
feat: 픽셀 씬 클릭 시 ghost 좌표 이동

### DIFF
--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -45,7 +45,7 @@ export default function HomePage() {
       </div>
 
       {/* 오버레이 콘텐츠 */}
-      <div className="flex relative z-10 flex-col justify-between gap-4 items-center px-6 py-12 w-full h-full md:w-1/2 md:ml-auto md:py-[72px] md:px-10">
+      <div className="flex relative z-10 flex-col justify-between gap-4 items-center px-6 py-12 w-full h-full pointer-events-none md:w-1/2 md:ml-auto md:py-[72px] md:px-10">
         <HomeHero />
         <LatestPosts posts={latestPosts} />
       </div>

--- a/src/components/home/HomeHero.tsx
+++ b/src/components/home/HomeHero.tsx
@@ -20,7 +20,7 @@ export default function HomeHero() {
   }, [fullName]);
 
   return (
-    <div className="w-full max-w-md md:max-w-none flex-shrink-0">
+    <div className="w-full max-w-md md:max-w-none flex-shrink-0 pointer-events-auto">
       <div className="bg-white/55 backdrop-blur-sm border border-gray-200 p-4 md:p-8">
         <div className="flex gap-4 items-center mb-3 md:mb-6">
           <Image

--- a/src/components/home/LatestPosts.tsx
+++ b/src/components/home/LatestPosts.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function LatestPosts({ posts }: Props) {
   return (
-    <div className="min-h-24 flex flex-col max-w-md w-full md:max-w-none">
+    <div className="min-h-24 flex flex-col max-w-md w-full md:max-w-none pointer-events-auto">
       <div className="bg-white/55 backdrop-blur-sm border border-gray-200 p-4 md:p-8 h-full overflow-hidden flex flex-col">
         <h2 className="text-sm font-bold text-green-700 mb-3 md:mb-4 flex items-center gap-2 flex-shrink-0">
           <span className="text-gray-700 select-none">{"//"}</span>

--- a/src/components/home/PixelScene.tsx
+++ b/src/components/home/PixelScene.tsx
@@ -89,12 +89,37 @@ export default function PixelScene() {
       });
       const ghost = new PIXI.AnimatedSprite(ghostTextures);
       ghost.animationSpeed = prefersReducedMotion ? 0 : 0.12;
-      ghost.scale.set(-4, 4); 
+      ghost.scale.set(-4, 4);
       ghost.anchor.set(0.5);
       ghost.x = W * 0.3;
       ghost.y = H * 0.45;
       ghost.play();
       app.stage.addChild(ghost);
+
+      // Click-to-move: ghost glides toward the clicked point
+      let baseX = W * 0.3;
+      let baseY = H * 0.45;
+      let targetX = baseX;
+      let targetY = baseY;
+      let moved = false;
+
+      app.stage.eventMode = "static";
+      app.stage.hitArea = app.screen;
+      app.stage.cursor = "pointer";
+      app.stage.on(
+        "pointertap",
+        (e: import("pixi.js").FederatedPointerEvent) => {
+          targetX = e.global.x;
+          targetY = e.global.y;
+          moved = true;
+          if (prefersReducedMotion) {
+            baseX = targetX;
+            baseY = targetY;
+            ghost.x = baseX;
+            ghost.y = baseY;
+          }
+        },
+      );
 
       // Ticker: parallax scroll + ghost bob/fade
       if (!prefersReducedMotion) {
@@ -104,7 +129,10 @@ export default function PixelScene() {
           BG_LAYERS.forEach(({ speed }, i) => {
             bgSprites[i].sprite.tilePosition.x -= speed;
           });
-          ghost.y = H * 0.45 + Math.sin(elapsed / 900) * 18;
+          baseX += (targetX - baseX) * 0.08;
+          baseY += (targetY - baseY) * 0.08;
+          ghost.x = baseX;
+          ghost.y = baseY + Math.sin(elapsed / 900) * 18;
           ghost.alpha = 0.75 + Math.sin(elapsed / 1200) * 0.25;
         });
       }
@@ -121,8 +149,12 @@ export default function PixelScene() {
           sprite.height = nH;
           sprite.tileScale.set(scale);
         });
-        ghost.x = nW * 0.3;
-        ghost.y = nH * 0.45;
+        if (!moved) {
+          baseX = targetX = nW * 0.3;
+          baseY = targetY = nH * 0.45;
+          ghost.x = baseX;
+          ghost.y = baseY;
+        }
       };
       window.addEventListener("resize", onResize);
     };


### PR DESCRIPTION
## 배경 및 목적

- 홈 픽셀 씬의 ghost는 현재 고정 위치에서 bob/fade 애니메이션을 수행 중
- 여기에 방문자가 클릭한 좌표로 ghost가 따라오는 인터랙션을 추가해, 랜딩 화면에 참여 요소를 더하고자 함
- 초기 구현 단계의 점진적 기능 추가이며, 기존 동작의 결함을 고치는 변경은 아님

## 설계

- 클릭 좌표를 즉시 대입하지 않고 **기준 위치(baseX/baseY)를 목표 좌표로 매 프레임 보간(lerp)** 하는 방식 채택 → 순간이동보다 자연스러운 글라이딩
- 기존 bob(상하 sin)·fade(alpha sin) 애니메이션은 보간된 기준 위치 **위에 덧씌워** 동작을 보존
- 좌표계: 스테이지 변환이 없어 `e.global`이 곧 캔버스 픽셀 좌표 → 별도 변환 불필요
- 오버레이 카드가 캔버스 위(z-10)를 덮고 있어 클릭이 캔버스에 닿지 않던 문제를 `pointer-events` 계층으로 해결 (래퍼 차단 + 카드 재허용)

## 구현 내용

- **PixelScene.tsx**: `app.stage`를 인터랙티브(`eventMode="static"`, `hitArea=app.screen`)로 설정, `pointertap`으로 목표 좌표 수신. 티커에서 기준 위치를 목표로 보간하고 bob/fade 적용. `prefers-reduced-motion` 시 즉시 이동, 리사이즈 시 미이동 상태면 기존 비율 위치 유지
- **page.tsx**: z-10 오버레이 래퍼에 `pointer-events-none` 부여 → 카드 사이 빈 공간 클릭이 캔버스로 통과
- **HomeHero.tsx / LatestPosts.tsx**: 카드 루트에 `pointer-events-auto` 부여 → 카드 본체·내부 링크 클릭은 그대로 유지

## 코드 리뷰 포인트

- 보간 계수 `0.08`로 이동 속도 결정 — 더 빠르거나 즉각적인 반응이 좋다면 조정 가능
- 카드 위를 클릭하면 ghost는 이동하지 않음(카드는 콘텐츠이므로 의도된 동작). 카드 위에서도 이동시키려면 별도 처리 필요
- 컨테이너에 `aria-hidden="true"`가 유지되어 이 인터랙션은 보조기기·키보드 사용자에게 노출되지 않음(장식 요소로 분류)

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 (시각적 위치/애니메이션 기본 동작 동일, 클릭 시에만 이동 추가)
- [x] 외부 파일·설정 수정 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `tsc --noEmit`, `next lint` 통과 (변경 파일 기준)
