### PR TITLE
refactor: useTypewriter 훅 추출 및 중복 제거

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,24 +1,13 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import { categories, tags, sitemap, blogInfo } from "@/data/dummyData";
 import ThemeToggle from "@/components/common/ThemeToggle";
+import { useTypewriter } from "@/hooks/useTypewriter";
 
 export default function Sidebar({ className, hideLogo }: { className?: string; hideLogo?: boolean }) {
-  const [typedName, setTypedName] = useState("");
-  const fullName = blogInfo.author.name;
-
-  useEffect(() => {
-    let i = 0;
-    const interval = setInterval(() => {
-      setTypedName(fullName.slice(0, i + 1));
-      i++;
-      if (i >= fullName.length) clearInterval(interval);
-    }, 150);
-    return () => clearInterval(interval);
-  }, [fullName]);
+  const typedName = useTypewriter(blogInfo.author.name);
 
   return (
     <aside className={`flex flex-col w-72 bg-[var(--color-bg)] border-r border-[var(--color-surface)] sticky top-0 h-screen overflow-y-auto p-6 ${className ?? ''}`}>

--- a/src/components/home/HomeHero.tsx
+++ b/src/components/home/HomeHero.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { blogInfo } from "@/data/dummyData";
+import { useTypewriter } from "@/hooks/useTypewriter";
 
 export default function HomeHero() {
-  const [typedName, setTypedName] = useState("");
-  const fullName = blogInfo.author.name;
-
-  useEffect(() => {
-    let i = 0;
-    const id = setInterval(() => {
-      setTypedName(fullName.slice(0, i + 1));
-      i++;
-      if (i >= fullName.length) clearInterval(id);
-    }, 150);
-    return () => clearInterval(id);
-  }, [fullName]);
+  const typedName = useTypewriter(blogInfo.author.name);
 
   return (
     <div className="w-full max-w-md md:max-w-none flex-shrink-0 pointer-events-auto">

--- a/src/hooks/useTypewriter.ts
+++ b/src/hooks/useTypewriter.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * 텍스트를 한 글자씩 타이핑하는 효과를 제공하는 훅.
+ * @param text - 타이핑할 전체 문자열
+ * @param speedMs - 글자당 타이핑 간격(ms), 기본값 150
+ * @returns 현재까지 타이핑된 문자열
+ */
+export function useTypewriter(text: string, speedMs = 150): string {
+  const [typed, setTyped] = useState("");
+
+  useEffect(() => {
+    setTyped("");
+    let i = 0;
+    const id = setInterval(() => {
+      setTyped(text.slice(0, i + 1));
+      i++;
+      if (i >= text.length) clearInterval(id);
+    }, speedMs);
+    return () => clearInterval(id);
+  }, [text, speedMs]);
+
+  return typed;
+}


### PR DESCRIPTION
## 배경 및 목적

- `HomeHero`·`Sidebar` 두 컴포넌트에 `setInterval` 기반 타이핑 효과 로직이 동일하게 중복 존재
- 커스텀 훅으로 추출해 단일 변경 지점 확보 및 재사용성 향상

## 설계

- JS `setInterval` 방식의 중복 2곳만 대상 — CSS 기반 타이핑(`header.tsx` 인라인 + `globals.css`)은 별개 관심사로 이번 범위에서 제외
- `text`·`speedMs` 파라미터화로 속도 조정 가능하도록 설계
- 외부에서 `text`가 바뀌면 타이핑을 처음부터 재시작하도록 `useEffect` deps에 포함

## 구현 내용

- `src/hooks/useTypewriter.ts` 신규 생성 — `useTypewriter(text, speedMs = 150): string` JSDoc 포함
- `src/components/home/HomeHero.tsx` — 로컬 `useState`·`useEffect` 제거, `useTypewriter` 적용
- `src/components/common/Sidebar.tsx` — 동일하게 적용, `useState`·`useEffect` import 제거

## 코드 리뷰 포인트

- `useTypewriter` 내부에서 `text` 변경 시 `setTyped("")` 초기화 후 재타이핑 시작 — `text`가 런타임에 바뀌는 경우 의도한 동작인지 확인
- `"use client"` 지시문을 훅 파일에 선언 — 훅을 사용하는 컴포넌트가 이미 Client Component이므로 실질적 영향 없음

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 — 타이핑 동작·속도 동일
- [x] 외부 파일·설정 수정 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음 (`yarn build` 통과 확인)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 이름이 한 글자씩 타이핑되는 애니메이션이 더 재사용하기 쉬운 방식으로 적용되었습니다.
  * 타이핑 속도를 조절할 수 있는 새 동작이 추가되었습니다.
* **Refactor**
  * 홈 화면과 사이드바의 타이핑 로직이 단순화되어, 더 일관된 동작을 제공합니다.
  * 관련 불필요한 코드와 의존성이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->