### PR TITLE
refactor: category·tag 페이지 구조 공용화

### DIFF
--- a/src/app/(main)/category/[slug]/page.tsx
+++ b/src/app/(main)/category/[slug]/page.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { categories, posts } from "@/data/dummyData";
 import { buildMetadata } from "@/lib/metadata";
+import TaxonomyPostList from "@/components/blog/TaxonomyPostList";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -33,27 +33,5 @@ export default async function CategoryPage({
 
   const filteredPosts = posts.filter((p) => p.categorySlug === slug);
 
-  return (
-    <section className="max-w-4xl mx-auto">
-      <h1 className="text-4xl font-bold mb-6 text-[var(--color-accent)]">
-        {category.name}
-      </h1>
-      <ul className="space-y-6">
-        {filteredPosts.map((post) => (
-          <li
-            key={post.id}
-            className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
-          >
-            <Link
-              href={`/blog/${post.slug}`}
-              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
-            >
-              {post.title}
-            </Link>
-            <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
+  return <TaxonomyPostList title={category.name} posts={filteredPosts} />;
 }

--- a/src/app/(main)/category/page.tsx
+++ b/src/app/(main)/category/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { categories } from "@/data/dummyData";
 import { buildMetadata } from "@/lib/metadata";
+import TaxonomyIndexGrid from "@/components/blog/TaxonomyIndexGrid";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = buildMetadata({
@@ -10,23 +10,13 @@ export const metadata: Metadata = buildMetadata({
 
 export default function CategoryIndex() {
   return (
-    <section className="max-w-4xl mx-auto">
-      <h1 className="text-4xl font-bold mb-8 text-[var(--color-accent)]">Categories</h1>
-      <ul className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {categories.map((cat) => (
-          <li
-            key={cat.id}
-            className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
-          >
-            <Link
-              href={`/category/${cat.slug}`}
-              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
-            >
-              {cat.name} ({cat.count})
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <TaxonomyIndexGrid
+      title="Categories"
+      items={categories.map((cat) => ({
+        key: cat.id,
+        href: `/category/${cat.slug}`,
+        label: `${cat.name} (${cat.count})`,
+      }))}
+    />
   );
 }

--- a/src/app/(main)/tag/[slug]/page.tsx
+++ b/src/app/(main)/tag/[slug]/page.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { tags, posts } from "@/data/dummyData";
 import { buildMetadata } from "@/lib/metadata";
+import TaxonomyPostList from "@/components/blog/TaxonomyPostList";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
@@ -35,27 +35,5 @@ export default async function TagPage({
     p.tags.map((t) => t.toLowerCase()).includes(slug.toLowerCase())
   );
 
-  return (
-    <section className="max-w-4xl mx-auto">
-      <h1 className="text-4xl font-bold mb-6 text-[var(--color-accent)]">
-        Tag: {tag.name}
-      </h1>
-      <ul className="space-y-6">
-        {filteredPosts.map((post) => (
-          <li
-            key={post.id}
-            className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
-          >
-            <Link
-              href={`/blog/${post.slug}`}
-              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
-            >
-              {post.title}
-            </Link>
-            <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
+  return <TaxonomyPostList title={`Tag: ${tag.name}`} posts={filteredPosts} />;
 }

--- a/src/app/(main)/tag/page.tsx
+++ b/src/app/(main)/tag/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { tags } from "@/data/dummyData";
 import { buildMetadata } from "@/lib/metadata";
+import TaxonomyIndexGrid from "@/components/blog/TaxonomyIndexGrid";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = buildMetadata({
@@ -10,23 +10,13 @@ export const metadata: Metadata = buildMetadata({
 
 export default function TagIndex() {
   return (
-    <section className="max-w-4xl mx-auto">
-      <h1 className="text-4xl font-bold mb-8 text-[var(--color-accent)]">Tags</h1>
-      <ul className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {tags.map((tag) => (
-          <li
-            key={tag.id}
-            className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
-          >
-            <Link
-              href={`/tag/${tag.name.toLowerCase()}`}
-              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
-            >
-              {tag.name} ({tag.count})
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <TaxonomyIndexGrid
+      title="Tags"
+      items={tags.map((tag) => ({
+        key: tag.id,
+        href: `/tag/${tag.name.toLowerCase()}`,
+        label: `${tag.name} (${tag.count})`,
+      }))}
+    />
   );
 }

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -32,9 +32,9 @@ export default function PostCard({ post }: PostCardProps) {
           {post.excerpt}
         </p>
         <div className="hidden sm:flex flex-wrap gap-2 mt-3">
-          {post.tags.slice(0, 3).map((tag, index) => (
+          {post.tags.slice(0, 3).map((tag) => (
             <span
-              key={index}
+              key={tag}
               className="inline-block px-2 py-0.5 text-xs font-medium text-[var(--color-accent)] bg-[var(--color-bg)] border border-[var(--color-accent)]/30"
             >
               #{tag}

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -92,9 +92,9 @@ export default function PostDetail({ post }: PostDetailProps) {
 
         {/* 태그 */}
         <div className="flex flex-wrap gap-2 mt-4">
-          {post.tags.map((tag, index) => (
+          {post.tags.map((tag) => (
             <Link
-              key={index}
+              key={tag}
               href={`/tag/${tag.toLowerCase()}`}
               className="inline-block px-3 py-1 text-sm font-medium text-[var(--color-accent)] bg-[var(--color-bg)] border border-[var(--color-accent)]/30 hover:bg-[var(--color-surface)] transition-colors"
             >

--- a/src/components/blog/TaxonomyIndexGrid.tsx
+++ b/src/components/blog/TaxonomyIndexGrid.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+interface TaxonomyIndexItem {
+  key: string | number;
+  href: string;
+  label: string;
+}
+
+interface TaxonomyIndexGridProps {
+  title: string;
+  items: TaxonomyIndexItem[];
+}
+
+/**
+ * 카테고리·태그 인덱스 그리드.
+ * category·tag 인덱스 페이지가 제목과 항목 목록만 달리하여 공유한다.
+ * @param title - 페이지 상단 제목 (예: "Categories", "Tags")
+ * @param items - 각 항목의 고유 key·링크 href·표시 label
+ */
+export default function TaxonomyIndexGrid({ title, items }: TaxonomyIndexGridProps) {
+  return (
+    <section className="max-w-4xl mx-auto">
+      <h1 className="text-4xl font-bold mb-8 text-[var(--color-accent)]">{title}</h1>
+      <ul className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {items.map((item) => (
+          <li
+            key={item.key}
+            className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
+          >
+            <Link
+              href={item.href}
+              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
+            >
+              {item.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/blog/TaxonomyPostList.tsx
+++ b/src/components/blog/TaxonomyPostList.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import type { Post } from "@/types";
+
+interface TaxonomyPostListProps {
+  title: string;
+  posts: Post[];
+}
+
+/**
+ * 카테고리·태그별로 필터링된 포스트 목록 섹션.
+ * category/[slug]·tag/[slug] 페이지가 제목과 포스트 배열만 달리하여 공유한다.
+ * @param title - 섹션 상단 제목 (예: 카테고리명, "Tag: React")
+ * @param posts - 렌더할 포스트 배열
+ */
+export default function TaxonomyPostList({ title, posts }: TaxonomyPostListProps) {
+  return (
+    <section className="max-w-4xl mx-auto">
+      <h1 className="text-4xl font-bold mb-6 text-[var(--color-accent)]">{title}</h1>
+      <ul className="space-y-6">
+        {posts.map((post) => (
+          <li
+            key={post.id}
+            className="bg-[var(--color-surface)] rounded-lg p-4 hover:bg-[var(--color-muted)] transition"
+          >
+            <Link
+              href={`/blog/${post.slug}`}
+              className="text-xl font-medium text-[var(--color-accent)] hover:underline"
+            >
+              {post.title}
+            </Link>
+            <p className="text-[var(--color-secondary)] mt-2">{post.excerpt}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/home/LatestPosts.tsx
+++ b/src/components/home/LatestPosts.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
 import type { Post } from "@/types";
 
-interface Props {
+interface LatestPostsProps {
   posts: Post[];
 }
 
-export default function LatestPosts({ posts }: Props) {
+export default function LatestPosts({ posts }: LatestPostsProps) {
   return (
     <div className="min-h-24 flex flex-col max-w-md w-full md:max-w-none pointer-events-auto">
       <p className="hidden md:block mb-1.5 text-[10px] text-gray-400 text-left select-none">


### PR DESCRIPTION
## 배경 및 목적

- `category/[slug]`·`tag/[slug]` 페이지가 포스트 목록 렌더 마크업을 동일하게 중복 보유
- `category`·`tag` 인덱스 페이지도 그리드 카드 마크업이 동일하게 중복
- 공용 컴포넌트로 추출해 레이아웃 단일 관리 및 페이지 코드 슬림화

## 설계

- 두 종류 중복을 각각 컴포넌트로 분리
  - `TaxonomyPostList` — `[slug]` 페이지용 포스트 목록 (제목 + posts만 주입)
  - `TaxonomyIndexGrid` — 인덱스 페이지용 그리드 (제목 + 항목 목록만 주입)
- 페이지는 데이터 조회·필터·메타데이터 생성 책임만 유지, 렌더는 공용 컴포넌트에 위임
- 인덱스 그리드는 `{ key, href, label }` 형태로 항목을 추상화해 category·tag 양쪽 수용

## 구현 내용

- `src/components/blog/TaxonomyPostList.tsx` 신규 — JSDoc 포함
- `src/components/blog/TaxonomyIndexGrid.tsx` 신규 — JSDoc 포함
- `category/[slug]`·`tag/[slug]` 페이지 — 인라인 마크업 제거, `TaxonomyPostList` 적용
- `category`·`tag` 인덱스 페이지 — 인라인 마크업 제거, `TaxonomyIndexGrid` 적용
- 동반 정리 (별도 커밋)
  - `PostCard`·`PostDetail`의 태그 `key={index}` → `key={tag}` (안정적 key)
  - `LatestPosts`의 `interface Props` → `LatestPostsProps` (네이밍 일관화)

## 코드 리뷰 포인트

- `TaxonomyIndexGrid`의 `label`이 `"이름 (개수)"` 문자열을 그대로 받음 — 표시 형식을 페이지가 결정하도록 의도한 설계
- 4개 페이지 모두 동작·스타일 변화 없음 — 마크업을 컴포넌트로 1:1 이동만 수행

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 — 렌더 결과·라우팅·메타데이터 동일
- [x] 외부 파일·설정 수정 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 카테고리 및 태그 목록/상세 페이지의 화면 구성이 더 일관된 공용 목록/그리드 형태로 정리되었습니다.
* **개선 사항**
  * 카테고리·태그 인덱스 페이지의 탐색이 더 깔끔하고 반응형으로 표시됩니다.
  * 글 상세와 카드의 태그 표시가 더 안정적으로 렌더링되도록 개선되었습니다.
  * 최신 글 영역의 내부 구조가 정리되어 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->