### PR TITLE
refactor: 본문 SSG 복구 + 조회수 클라이언트 분리

### DIFF
--- a/src/app/(main)/blog/[slug]/page.tsx
+++ b/src/app/(main)/blog/[slug]/page.tsx
@@ -1,12 +1,8 @@
 import { notFound } from "next/navigation";
 import PostDetail from "@/components/blog/PostDetail";
 import { posts } from "@/data/dummyData";
-import { incrementViewCount } from "@/lib/data/posts";
 import { buildMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
-
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
 
 export function generateStaticParams() {
   return posts.map((post) => ({ slug: post.slug }));
@@ -40,7 +36,5 @@ export default async function PostPage({
   const post = posts.find((p) => p.slug === slug);
   if (!post) notFound();
 
-  const viewCount = await incrementViewCount(slug);
-
-  return <PostDetail post={post} viewCount={viewCount} />;
+  return <PostDetail post={post} />;
 }

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
+import ViewCounter from "@/components/blog/ViewCounter";
 import type { Post, TocItem } from "@/types";
 
 interface PostDetailProps {
   post: Post;
-  viewCount: number;
 }
 
-export default function PostDetail({ post, viewCount }: PostDetailProps) {
+export default function PostDetail({ post }: PostDetailProps) {
 
   // 목차 생성 (간단한 버전)
   const tableOfContents: TocItem[] = [
@@ -87,7 +87,7 @@ export default function PostDetail({ post, viewCount }: PostDetailProps) {
                 d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
               />
             </svg>
-            {viewCount.toLocaleString()} views
+            <ViewCounter slug={post.slug} />
           </span>
         </div>
 

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -87,7 +87,7 @@ export default function PostDetail({ post }: PostDetailProps) {
                 d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
               />
             </svg>
-            <ViewCounter slug={post.slug} />
+            <ViewCounter key={post.slug} slug={post.slug} />
           </span>
         </div>
 

--- a/src/components/blog/ViewCounter.tsx
+++ b/src/components/blog/ViewCounter.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { bumpView } from "@/lib/actions/views";
+
+// 본문은 정적(SSG)으로 두고, 조회수만 클라이언트 마운트 시 +1 후 갱신값을 표시한다.
+// 값이 도착하기 전에는 "—"를 보여준다(본문·SEO에는 영향 없음).
+export default function ViewCounter({ slug }: { slug: string }) {
+  const [count, setCount] = useState<number | null>(null);
+  // StrictMode(개발)에서 effect가 두 번 실행돼 중복 증가하는 것을 막는다.
+  const bumpedSlug = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (bumpedSlug.current === slug) return;
+    bumpedSlug.current = slug;
+    bumpView(slug)
+      .then(setCount)
+      .catch(() => {});
+  }, [slug]);
+
+  return <>{count === null ? "—" : count.toLocaleString()} views</>;
+}

--- a/src/lib/actions/views.ts
+++ b/src/lib/actions/views.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { incrementViewCount } from "@/lib/data/posts";
+
+// 클라이언트에서 호출하는 쓰기 진입점. 진입 시 조회수 +1 후 갱신된 값을 돌려준다.
+// slug 검증은 incrementViewCount 내부(assertValidPostSlug)에서 수행하므로
+// 임의 문자열로 가짜 레코드를 만들 수 없다.
+export async function bumpView(slug: string) {
+  return incrementViewCount(slug);
+}

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -7,14 +7,6 @@ function assertValidPostSlug(slug: string) {
   }
 }
 
-// 글의 현재 조회수를 읽는다. 아직 레코드가 없으면 0.
-export async function getViewCount(slug: string) {
-  assertValidPostSlug(slug);
-
-  const post = await prisma.post.findUnique({ where: { slug } });
-  return post?.viewCount ?? 0;
-}
-
 // 조회수를 1 올린다. 레코드가 없으면 생성하면서 1로 시작.
 export async function incrementViewCount(slug: string) {
   assertValidPostSlug(slug);


### PR DESCRIPTION
## 배경 및 목적

조회수 기능(M2)은 동작하지만, 직전 구현은 글 상세 라우트 전체를 `force-dynamic`으로 두어 조회수 정확성을 확보하는 대신 **본문의 정적 생성(SSG) 이점을 매 요청 SSR로 대체**하고 있었습니다. 본 PR은 조회수의 정확성·안전성은 그대로 유지하면서 **본문 SSG를 복원**해, 정적화의 캐시·응답속도 이점과 동적 조회수를 양립시키는 것을 목적으로 합니다.

## 설계

- **본문 = 정적(SSG), 조회수 = 클라이언트 동적**으로 책임을 분리했습니다.
  - 글 상세 `page`는 `generateStaticParams` 기반 정적 생성으로 복귀(`force-dynamic`/`revalidate=0` 제거).
  - 조회수만 클라이언트 컴포넌트(`ViewCounter`)가 마운트 시 Server Action(`bumpView`)으로 +1하고 **반환값을 즉시 표시**합니다.
- 대안 비교
  - (A) 기존 plan 방식 — `getViewCount` 읽기 + `ViewTracker` effect 증가: 정적 페이지에서 표시값이 빌드 시점에 고정되고, 첫 렌더에 현재 방문이 누락되는 문제.
  - (B) 직전 커밋 방식 — `force-dynamic` + 서버에서 직접 증가: 정확하지만 본문 SSG 포기.
  - (C, 본 PR) 본문 정적 + 조회수만 클라이언트: 정확성(A의 문제 해결)과 SSG(B의 비용 회피)를 모두 확보. 대가는 조회수가 하이드레이션 후 표시되는 것뿐이며 본문·SEO에는 영향 없음.

## 구현 내용

- `src/lib/actions/views.ts` (신규) — `"use server"` `bumpView(slug)`: `incrementViewCount` 호출 후 갱신된 조회수 반환. slug 검증은 내부 `assertValidPostSlug`가 담당.
- `src/components/blog/ViewCounter.tsx` (신규) — `"use client"`. 마운트 시 `bumpView` 호출 → 반환값 표시. 값 도착 전 `—` 노출, `useRef` slug 가드로 StrictMode 이중 증가 방지.
- `src/components/blog/PostDetail.tsx` — `viewCount` props 제거, 조회수 자리에 `<ViewCounter slug={post.slug} />` 삽입(아이콘은 유지).
- `src/app/(main)/blog/[slug]/page.tsx` — `force-dynamic`/`revalidate=0`·서버 측 `incrementViewCount` 호출·`viewCount` props 제거 → 정적 생성 복귀.
- `src/lib/data/posts.ts` — 조회수 표시가 `bumpView` 반환값으로 일원화되며 미사용이 된 `getViewCount` 제거(`incrementViewCount`만 유지).

## 코드 리뷰 포인트

- 직전 리뷰에서 지적된 3가지가 본 구조에서도 충족되는지 확인 부탁드립니다.
  - 정적 고정 → 조회수는 클라이언트가 동적으로 가져와 항상 최신.
  - 증가 타이밍 → 서버에서 +1 후 **반환값**을 표시해 이번 방문 즉시 반영.
  - 보안 → 공개 Action `bumpView`가 `assertValidPostSlug`로 임의 slug를 차단.
- 트레이드오프: 조회수는 하이드레이션 이후 표시되어 첫 페인트에는 `—`로 보입니다(부차 정보라 의도적으로 수용).

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 — 조회수 표시 위치·형식 동일, 본문 렌더 결과 동일.
- [x] 외부 파일·설정 수정 없음.
- [x] 연관 커맨드·스크립트 동작 변화 없음.

## 테스트

- `tsc --noEmit` 통과.
- 조회수 중복 방지(새로고침·중복 진입 시 +1)는 plan의 M5 영역으로 본 PR 범위에 포함하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 블로그 글 상세 화면에 조회수 표시가 추가되었고, 페이지 로드 후 최신 조회수가 갱신되어 표시됩니다.
  * 조회수는 글이 표시된 뒤 자동으로 1회 반영되며, 로딩 전에는 대체 표기가 노출됩니다.
* **Bug Fixes**
  * 서버에서 미리 전달되던 값에 의존하지 않도록 동작 방식을 개선했습니다.
  * 개발 환경의 중복 호출로 조회수가 두 번 이상 증가하는 문제를 방지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->