### PR TITLE
feat: GitHub 로그인 + 댓글 기능 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,12 @@
 
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      // GitHub 프로필 아바타(로그인 사용자 표시용)
+      { protocol: "https", hostname: "avatars.githubusercontent.com" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/prisma/migrations/20260630081554_add_user_email_verified/migration.sql
+++ b/prisma/migrations/20260630081554_add_user_email_verified/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "emailVerified" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,13 +36,14 @@ model Comment {
 
 // ── 아래 4개는 Auth.js(@auth/prisma-adapter) 표준 모델 ──
 model User {
-  id       String    @id @default(cuid())
-  name     String?
-  email    String?   @unique
-  image    String?
-  accounts Account[]
-  sessions Session[]
-  comments Comment[]
+  id            String    @id @default(cuid())
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime?
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+  comments      Comment[]
 }
 
 model Account {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,4 @@
+import { handlers } from "@/auth";
+
+// Auth.js의 모든 인증 엔드포인트(로그인/콜백/세션 등)를 처리하는 유일한 Route Handler.
+export const { GET, POST } = handlers;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,20 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import { prisma } from "@/lib/prisma";
+
+// Auth.js v5 설정. GitHub OAuth로 로그인하고, 세션·계정 정보는 Prisma 어댑터를
+// 통해 DB(User/Account/Session 테이블)에 저장한다(database 세션 전략).
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  providers: [GitHub],
+  session: { strategy: "database" },
+  callbacks: {
+    // database 세션의 user(id 포함)를 클라이언트 세션에도 노출한다.
+    // 댓글 작성·삭제에서 session.user.id로 작성자를 식별하기 위함.
+    session({ session, user }) {
+      session.user.id = user.id;
+      return session;
+    },
+  },
+});

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import CommentSection from "@/components/blog/comments/CommentSection";
 import type { Post, TocItem } from "@/types";
 
 interface PostDetailProps {
@@ -214,6 +215,9 @@ export default function PostDetail({ post, viewCount }: PostDetailProps) {
           </div>
         </aside>
       </div>
+
+      {/* 댓글 영역 */}
+      <CommentSection slug={post.slug} />
 
       {/* 이전/다음 포스트 네비게이션 */}
       <div className="mt-16 pt-8 border-t border-[var(--color-muted)]">

--- a/src/components/blog/comments/CommentForm.tsx
+++ b/src/components/blog/comments/CommentForm.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
+import { createComment } from "@/lib/actions/comments";
+import { MAX_COMMENT_LENGTH } from "@/lib/constants";
+
+// 제출 중에는 useFormStatus로 pending을 감지해 버튼을 비활성화하고 라벨을 바꾼다.
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="px-4 py-2 text-sm text-[var(--color-accent)] bg-[var(--color-bg)] hover:bg-[var(--color-muted)] border border-[var(--color-accent)]/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? "등록 중…" : "등록"}
+    </button>
+  );
+}
+
+// 댓글 작성 폼(클라이언트). createComment(Server Action)를 호출하고,
+// 성공하면 입력창과 글자 수 카운터를 비운다. 목록 갱신은 액션 내부의
+// revalidatePath가 담당한다.
+export default function CommentForm({ slug }: { slug: string }) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [count, setCount] = useState(0);
+
+  // 한도의 90% 이상이면 강조색으로 남은 글자가 적음을 알린다.
+  const nearLimit = count >= MAX_COMMENT_LENGTH * 0.9;
+
+  return (
+    <form
+      ref={formRef}
+      action={async (formData) => {
+        await createComment(formData);
+        formRef.current?.reset();
+        setCount(0);
+      }}
+      className="flex flex-col gap-3"
+    >
+      <input type="hidden" name="slug" value={slug} />
+      <textarea
+        name="content"
+        required
+        maxLength={MAX_COMMENT_LENGTH}
+        rows={3}
+        placeholder={`댓글을 입력하세요 (최대 ${MAX_COMMENT_LENGTH}자)`}
+        onChange={(e) => setCount(e.target.value.length)}
+        className="w-full resize-y bg-[var(--color-bg)] border border-[var(--color-muted)] p-3 text-sm text-[var(--color-secondary)] focus:outline-none focus:border-[var(--color-accent)] transition-colors"
+      />
+      <div className="flex items-center justify-between">
+        <span
+          className={`text-xs ${nearLimit ? "text-[var(--color-accent)] font-medium" : "text-[var(--color-secondary)]"}`}
+        >
+          {count}/{MAX_COMMENT_LENGTH}
+        </span>
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}

--- a/src/components/blog/comments/CommentForm.tsx
+++ b/src/components/blog/comments/CommentForm.tsx
@@ -25,6 +25,7 @@ function SubmitButton() {
 export default function CommentForm({ slug }: { slug: string }) {
   const formRef = useRef<HTMLFormElement>(null);
   const [count, setCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
 
   // 한도의 90% 이상이면 강조색으로 남은 글자가 적음을 알린다.
   const nearLimit = count >= MAX_COMMENT_LENGTH * 0.9;
@@ -33,9 +34,23 @@ export default function CommentForm({ slug }: { slug: string }) {
     <form
       ref={formRef}
       action={async (formData) => {
-        await createComment(formData);
-        formRef.current?.reset();
-        setCount(0);
+        // 공백만 입력된 빈 댓글은 서버 호출 없이 즉시 차단한다(서버 스키마도 trim으로 재검증).
+        const content = String(formData.get("content") ?? "").trim();
+        if (!content) {
+          setError("내용을 입력해 주세요.");
+          return;
+        }
+
+        // createComment는 인증·slug·스키마 검증 실패 시 예외를 던진다.
+        // 성공했을 때만 입력창을 비우고, 실패하면 입력을 유지한 채 오류를 알린다.
+        try {
+          await createComment(formData);
+          formRef.current?.reset();
+          setCount(0);
+          setError(null);
+        } catch {
+          setError("댓글 등록에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+        }
       }}
       className="flex flex-col gap-3"
     >
@@ -46,9 +61,17 @@ export default function CommentForm({ slug }: { slug: string }) {
         maxLength={MAX_COMMENT_LENGTH}
         rows={3}
         placeholder={`댓글을 입력하세요 (최대 ${MAX_COMMENT_LENGTH}자)`}
-        onChange={(e) => setCount(e.target.value.length)}
+        onChange={(e) => {
+          setCount(e.target.value.length);
+          if (error) setError(null); // 다시 입력하면 이전 오류를 지운다
+        }}
         className="w-full resize-y bg-[var(--color-bg)] border border-[var(--color-muted)] p-3 text-sm text-[var(--color-secondary)] focus:outline-none focus:border-[var(--color-accent)] transition-colors"
       />
+      {error && (
+        <p role="alert" className="text-xs text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
       <div className="flex items-center justify-between">
         <span
           className={`text-xs ${nearLimit ? "text-[var(--color-accent)] font-medium" : "text-[var(--color-secondary)]"}`}

--- a/src/components/blog/comments/CommentItem.tsx
+++ b/src/components/blog/comments/CommentItem.tsx
@@ -4,12 +4,11 @@ import type { CommentWithAuthor } from "@/lib/data/comments";
 
 interface CommentItemProps {
   comment: CommentWithAuthor;
-  slug: string;
   currentUserId?: string;
 }
 
 // 댓글 1건. 본인 댓글에만 삭제 버튼을 노출한다(삭제는 서버에서 소유자 재검증).
-export default function CommentItem({ comment, slug, currentUserId }: CommentItemProps) {
+export default function CommentItem({ comment, currentUserId }: CommentItemProps) {
   const isOwner = !!currentUserId && comment.authorId === currentUserId;
   const createdAt = comment.createdAt.toLocaleDateString("ko-KR", {
     year: "numeric",
@@ -35,7 +34,7 @@ export default function CommentItem({ comment, slug, currentUserId }: CommentIte
           </span>
           <span className="text-xs text-[var(--color-secondary)]">{createdAt}</span>
         </div>
-        {isOwner && <DeleteButton id={comment.id} slug={slug} />}
+        {isOwner && <DeleteButton id={comment.id} />}
       </div>
       <p className="text-sm text-[var(--color-secondary)] whitespace-pre-wrap break-words">
         {comment.content}

--- a/src/components/blog/comments/CommentItem.tsx
+++ b/src/components/blog/comments/CommentItem.tsx
@@ -1,0 +1,45 @@
+import Image from "next/image";
+import DeleteButton from "./DeleteButton";
+import type { CommentWithAuthor } from "@/lib/data/comments";
+
+interface CommentItemProps {
+  comment: CommentWithAuthor;
+  slug: string;
+  currentUserId?: string;
+}
+
+// 댓글 1건. 본인 댓글에만 삭제 버튼을 노출한다(삭제는 서버에서 소유자 재검증).
+export default function CommentItem({ comment, slug, currentUserId }: CommentItemProps) {
+  const isOwner = !!currentUserId && comment.authorId === currentUserId;
+  const createdAt = comment.createdAt.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <li className="py-4 border-b border-[var(--color-muted)] last:border-b-0">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          {comment.author.image && (
+            <Image
+              src={comment.author.image}
+              alt={comment.author.name ?? "사용자"}
+              width={24}
+              height={24}
+              className="rounded-full border border-[var(--color-muted)]"
+            />
+          )}
+          <span className="text-sm font-medium text-[var(--color-accent)]">
+            {comment.author.name ?? "익명"}
+          </span>
+          <span className="text-xs text-[var(--color-secondary)]">{createdAt}</span>
+        </div>
+        {isOwner && <DeleteButton id={comment.id} slug={slug} />}
+      </div>
+      <p className="text-sm text-[var(--color-secondary)] whitespace-pre-wrap break-words">
+        {comment.content}
+      </p>
+    </li>
+  );
+}

--- a/src/components/blog/comments/CommentList.tsx
+++ b/src/components/blog/comments/CommentList.tsx
@@ -24,7 +24,6 @@ export default async function CommentList({ slug, currentUserId }: CommentListPr
         <CommentItem
           key={comment.id}
           comment={comment}
-          slug={slug}
           currentUserId={currentUserId}
         />
       ))}

--- a/src/components/blog/comments/CommentList.tsx
+++ b/src/components/blog/comments/CommentList.tsx
@@ -1,0 +1,33 @@
+import { getComments } from "@/lib/data/comments";
+import CommentItem from "./CommentItem";
+
+interface CommentListProps {
+  slug: string;
+  currentUserId?: string;
+}
+
+// 댓글 목록(Server Component). 서버에서 직접 조회한다(fetch 불필요).
+export default async function CommentList({ slug, currentUserId }: CommentListProps) {
+  const comments = await getComments(slug);
+
+  if (comments.length === 0) {
+    return (
+      <p className="py-6 text-sm text-[var(--color-secondary)]">
+        아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="mt-4">
+      {comments.map((comment) => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          slug={slug}
+          currentUserId={currentUserId}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/blog/comments/CommentSection.tsx
+++ b/src/components/blog/comments/CommentSection.tsx
@@ -1,0 +1,56 @@
+import Image from "next/image";
+import { auth, signOut } from "@/auth";
+import CommentList from "./CommentList";
+import CommentForm from "./CommentForm";
+import SignInPrompt from "./SignInPrompt";
+
+// 글 하단 댓글 영역. 로그인 여부에 따라 작성 영역(작성자 정보+폼) 또는 로그인
+// 유도를 보여주고, 그 아래에 댓글 목록을 렌더한다.
+export default async function CommentSection({ slug }: { slug: string }) {
+  const session = await auth();
+
+  return (
+    <section className="mt-16 pt-8 border-t border-[var(--color-muted)]">
+      <h2 className="text-xl font-bold text-[var(--color-accent)] mb-4">댓글</h2>
+
+      {session?.user ? (
+        <div className="bg-[var(--color-surface)] border border-[var(--color-muted)] p-5">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              {session.user.image && (
+                <Image
+                  src={session.user.image}
+                  alt={session.user.name ?? "사용자"}
+                  width={28}
+                  height={28}
+                  className="rounded-full border border-[var(--color-muted)]"
+                />
+              )}
+              <span className="text-sm font-medium text-[var(--color-accent)]">
+                {session.user.name ?? "익명"}
+              </span>
+            </div>
+            <form
+              action={async () => {
+                "use server";
+                await signOut();
+              }}
+            >
+              <button
+                type="submit"
+                className="text-xs text-[var(--color-secondary)] hover:text-[var(--color-accent)] underline-offset-2 hover:underline transition-colors"
+              >
+                로그아웃
+              </button>
+            </form>
+          </div>
+          <CommentForm slug={slug} />
+        </div>
+      ) : (
+        <SignInPrompt />
+      )}
+
+      <CommentList slug={slug} currentUserId={session?.user?.id} />
+    </section>
+  );
+}

--- a/src/components/blog/comments/DeleteButton.tsx
+++ b/src/components/blog/comments/DeleteButton.tsx
@@ -17,12 +17,11 @@ function SubmitButton() {
 }
 
 // 댓글 삭제 버튼(클라이언트). 작성 폼과 동일하게 클라이언트 컴포넌트를 경유해
-// Server Action을 호출한다. id·slug는 hidden input으로 전달한다.
-export default function DeleteButton({ id, slug }: { id: string; slug: string }) {
+// Server Action을 호출한다. id만 전달하고, 재검증 slug는 서버가 레코드에서 조회한다.
+export default function DeleteButton({ id }: { id: string }) {
   return (
     <form action={deleteComment}>
       <input type="hidden" name="id" value={id} />
-      <input type="hidden" name="slug" value={slug} />
       <SubmitButton />
     </form>
   );

--- a/src/components/blog/comments/DeleteButton.tsx
+++ b/src/components/blog/comments/DeleteButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import { deleteComment } from "@/lib/actions/comments";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="text-xs text-[var(--color-secondary)] hover:text-[var(--color-accent)] underline-offset-2 hover:underline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? "삭제 중…" : "삭제"}
+    </button>
+  );
+}
+
+// 댓글 삭제 버튼(클라이언트). 작성 폼과 동일하게 클라이언트 컴포넌트를 경유해
+// Server Action을 호출한다. id·slug는 hidden input으로 전달한다.
+export default function DeleteButton({ id, slug }: { id: string; slug: string }) {
+  return (
+    <form action={deleteComment}>
+      <input type="hidden" name="id" value={id} />
+      <input type="hidden" name="slug" value={slug} />
+      <SubmitButton />
+    </form>
+  );
+}

--- a/src/components/blog/comments/SignInPrompt.tsx
+++ b/src/components/blog/comments/SignInPrompt.tsx
@@ -1,0 +1,28 @@
+import { signIn } from "@/auth";
+
+// 비로그인 사용자에게 댓글 작성을 위한 GitHub 로그인을 유도한다.
+// 폼의 Server Action으로 처리하므로 JS 없이도 동작한다.
+export default function SignInPrompt() {
+  return (
+    <form
+      action={async () => {
+        "use server";
+        await signIn("github");
+      }}
+      className="flex flex-col items-start gap-3 bg-[var(--color-surface)] border border-[var(--color-muted)] p-5"
+    >
+      <p className="text-sm text-[var(--color-secondary)]">
+        댓글을 작성하려면 GitHub 로그인이 필요합니다.
+      </p>
+      <button
+        type="submit"
+        className="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-accent)] bg-[var(--color-bg)] hover:bg-[var(--color-muted)] border border-[var(--color-accent)]/40 transition-colors"
+      >
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.33-1.76-1.33-1.76-1.09-.74.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.49.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.31-.54-1.52.11-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 016.01 0c2.29-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.87.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.62-5.48 5.92.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.21.7.82.58A12 12 0 0024 12.5C24 5.87 18.63.5 12 .5z" />
+        </svg>
+        GitHub로 로그인
+      </button>
+    </form>
+  );
+}

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/auth";
+import { CommentSchema } from "@/lib/schemas";
+import { assertValidPostSlug } from "@/lib/data/posts";
+
+// 댓글 작성. 로그인 사용자만 가능하며, 실제 글 slug만 허용한다.
+export async function createComment(formData: FormData) {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error("unauthorized"); // 서버단 1차 방어
+
+  const { slug, content } = CommentSchema.parse({
+    slug: formData.get("slug"),
+    content: formData.get("content"),
+  });
+  assertValidPostSlug(slug); // 임의 slug로 가짜 댓글이 쌓이는 것을 막는다
+
+  await prisma.post.upsert({ where: { slug }, create: { slug }, update: {} }); // 앵커 보장
+  await prisma.comment.create({
+    data: { postSlug: slug, content, authorId: session.user.id },
+  });
+  revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
+}
+
+// 댓글 삭제. 본인 댓글만 삭제할 수 있다. 폼의 hidden input으로 id·slug를 받는다.
+export async function deleteComment(formData: FormData) {
+  const id = String(formData.get("id"));
+  const slug = String(formData.get("slug"));
+
+  const session = await auth();
+  const comment = await prisma.comment.findUnique({ where: { id } });
+  if (!comment) throw new Error("not found");
+  if (comment.authorId !== session?.user?.id) throw new Error("forbidden"); // 본인만
+  await prisma.comment.delete({ where: { id } });
+  revalidatePath(`/blog/${slug}`);
+}

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -24,15 +24,16 @@ export async function createComment(formData: FormData) {
   revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
 }
 
-// 댓글 삭제. 본인 댓글만 삭제할 수 있다. 폼의 hidden input으로 id·slug를 받는다.
+// 댓글 삭제. 본인 댓글만 삭제할 수 있다. 폼의 hidden input으로 id만 받는다.
 export async function deleteComment(formData: FormData) {
   const id = String(formData.get("id"));
-  const slug = String(formData.get("slug"));
 
   const session = await auth();
   const comment = await prisma.comment.findUnique({ where: { id } });
   if (!comment) throw new Error("not found");
   if (comment.authorId !== session?.user?.id) throw new Error("forbidden"); // 본인만
   await prisma.comment.delete({ where: { id } });
-  revalidatePath(`/blog/${slug}`);
+  // 재검증 대상 slug는 클라이언트 입력이 아니라 서버가 조회한 레코드에서 가져온다.
+  // (클라이언트가 slug를 위조하면 엉뚱한 글 캐시만 비워질 수 있으므로)
+  revalidatePath(`/blog/${comment.postSlug}`);
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,3 @@
+// 댓글 본문 최대 길이. 클라이언트 입력 제한(maxLength·카운터)과 서버 검증(zod)이
+// 공유한다. zod 의존이 없는 순수 상수 모듈이라 클라이언트 번들에 안전하다.
+export const MAX_COMMENT_LENGTH = 1000;

--- a/src/lib/data/comments.ts
+++ b/src/lib/data/comments.ts
@@ -1,0 +1,13 @@
+import { prisma } from "@/lib/prisma";
+
+// 글의 최상위 댓글 목록을 최신순으로 조회한다(작성자 정보 포함).
+// 대댓글(replies)은 스키마상 준비돼 있으나 작성 UI는 후속 단계에서 다룬다.
+export async function getComments(slug: string) {
+  return prisma.comment.findMany({
+    where: { postSlug: slug, parentId: null },
+    include: { author: true },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export type CommentWithAuthor = Awaited<ReturnType<typeof getComments>>[number];

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -1,7 +1,9 @@
 import { posts } from "@/data/dummyData";
 import { prisma } from "@/lib/prisma";
 
-function assertValidPostSlug(slug: string) {
+// 실제 존재하는 글의 slug인지 검증한다. 임의 문자열로 가짜 레코드(조회수·댓글)가
+// 쌓이는 것을 막기 위한 공용 가드.
+export function assertValidPostSlug(slug: string) {
   if (!posts.some((post) => post.slug === slug)) {
     throw new Error(`Invalid post slug: ${slug}`);
   }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -4,8 +4,11 @@ import { MAX_COMMENT_LENGTH } from "@/lib/constants";
 // 댓글 작성 입력 검증. 서버 액션에서 FormData를 파싱할 때 사용한다.
 export const CommentSchema = z.object({
   slug: z.string().min(1),
+  // 순서 중요: trim()으로 앞뒤 공백을 먼저 제거한 뒤 min(1)로 검사해야
+  // 공백만 입력한 빈 댓글(전각 공백 포함)이 거부된다. 순서를 바꾸면 검증이 뚫린다.
   content: z
     .string()
+    .trim()
     .min(1, "내용을 입력해 주세요.")
     .max(MAX_COMMENT_LENGTH, `${MAX_COMMENT_LENGTH}자 이내로 입력해 주세요.`),
 });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { MAX_COMMENT_LENGTH } from "@/lib/constants";
+
+// 댓글 작성 입력 검증. 서버 액션에서 FormData를 파싱할 때 사용한다.
+export const CommentSchema = z.object({
+  slug: z.string().min(1),
+  content: z
+    .string()
+    .min(1, "내용을 입력해 주세요.")
+    .max(MAX_COMMENT_LENGTH, `${MAX_COMMENT_LENGTH}자 이내로 입력해 주세요.`),
+});

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,10 @@
+import type { DefaultSession } from "next-auth";
+
+// 기본 Session.user에는 id가 없으므로, 댓글 작성자 식별을 위해 id를 추가한다.
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+}


### PR DESCRIPTION
## 배경 및 목적

블로그에 **독자와 상호작용할 수 있는 댓글**을 추가합니다. 댓글은 작성자 식별이 필요하므로, 그 토대로 **GitHub OAuth 로그인(Auth.js v5)** 을 함께 도입했습니다. 글 본문은 정적으로 유지하면서, 로그인·댓글이라는 동적 영역을 글 하단에 더해 블로그의 참여 가치를 넓힙니다.

## 설계

- **인증**: Auth.js v5 + `PrismaAdapter`, `database` 세션 전략. 세션 콜백으로 `user.id`를 노출해 댓글 작성자 식별에 사용합니다. 인증 엔드포인트는 표준 Route Handler(`/api/auth/[...nextauth]`) 하나만 둡니다.
- **로그인 진입점 위치**: 이 블로그에서 로그인의 유일한 목적은 댓글 작성이므로, 전역 헤더가 아니라 **댓글 영역에만** 배치했습니다(목적이 명확하고 UI가 단순).
- **데이터 접근**: 읽기는 Server Component가 직접 조회(DAL `getComments`), 쓰기는 Server Action(`createComment`/`deleteComment`) + `revalidatePath`로 즉시 갱신.
- **Server Action 호출 경로**: 작성·삭제 모두 **클라이언트 컴포넌트를 경유**해 호출합니다. 서버 컴포넌트의 `<form action={serverAction}>` 직접 연결은 이 환경(Next 14.2)에서 `apply` 에러를 일으켜, 검증된 경로로 통일했습니다.
- **가짜 레코드 방지**: 작성 시 `assertValidPostSlug`로 실제 글 slug만 허용(조회수와 공유하는 가드).

## 구현 내용

- `prisma/schema.prisma` / 마이그레이션 — `User.emailVerified` 추가(Auth.js 어댑터 표준 컬럼 누락 보정).
- `src/auth.ts`, `src/app/api/auth/[...nextauth]/route.ts`, `src/types/next-auth.d.ts` — 인증 설정·Route Handler·세션 타입 보강.
- `src/lib/data/comments.ts`, `src/lib/actions/comments.ts`, `src/lib/schemas.ts`, `src/lib/constants.ts` — 댓글 DAL·Server Action·Zod 검증·길이 상수.
- `src/lib/data/posts.ts` — `assertValidPostSlug` 공용 export.
- `src/components/blog/comments/*` — `CommentSection`/`CommentList`/`CommentItem`/`CommentForm`/`DeleteButton`/`SignInPrompt`.
- `src/components/blog/PostDetail.tsx` — 글 하단에 댓글 영역 삽입.
- `next.config.mjs` — GitHub 아바타 이미지 도메인 허용.

## 코드 리뷰 포인트

- 작성/삭제의 **클라이언트 경유 패턴**과 서버단 권한 재검증(`unauthorized`/`forbidden`) 흐름.
- 댓글 길이 한도(`MAX_COMMENT_LENGTH`)를 클라이언트 입력 제한·카운터·서버 검증이 **한 상수로 공유**하는지.
- 대댓글(`parentId`)은 스키마 컬럼만 두고 작성 경로는 넣지 않았습니다(향후 단계).

## 사이드이펙트 검토

- [x] 기존 사용자 breaking 없음 — 글 본문 렌더는 그대로, 댓글 영역만 글 하단에 추가.
- [x] 외부 파일·설정 수정 시 처리 — `next.config` 이미지 도메인 추가 외 없음.
- [x] 연관 커맨드·스크립트 동작 변화 없음.

## 로컬 실행에 필요한 `.env` 키 (값 제외)

```
DATABASE_URL          # Neon 풀링 연결(런타임)
DIRECT_URL            # Neon 직접 연결(마이그레이션)
AUTH_SECRET           # openssl rand -base64 33
AUTH_GITHUB_ID        # GitHub OAuth App Client ID
AUTH_GITHUB_SECRET    # GitHub OAuth App Client Secret
```

- GitHub OAuth App 콜백: `http://localhost:3000/api/auth/callback/github`
- 적용: `yarn prisma migrate deploy`(또는 `migrate dev`)로 `emailVerified` 마이그레이션 반영 필요.

## 테스트

- `tsc --noEmit` 통과.
- 수동 검증: GitHub 로그인 → `User`/`Account`/`Session` 생성, 댓글 작성·목록 즉시 갱신·본인 댓글 삭제, 비로그인 시 폼 비노출·로그인 유도.
- 조회수 중복 방지·rate limit·대댓글 UI는 후속(M5) 범위.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 블로그 글에 댓글 작성/목록 표시/삭제 기능이 추가되었습니다.
  * 댓글 작성을 위해 GitHub 로그인 기반 인증을 사용합니다.
  * GitHub 원격 아바타 이미지를 표시할 수 있게 되었습니다.
* **Bug Fixes**
  * 댓글 등록/삭제 후 해당 글 페이지가 즉시 최신 상태로 갱신됩니다.
  * 댓글 입력 길이 제한 및 공백만 입력된 경우 검증이 강화되었습니다.
* **Chores**
  * 사용자 이메일 확인 상태를 저장할 수 있는 항목이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->