### PR TITLE
feat: 댓글 답글(대댓글) 기능 추가

### DIFF
--- a/src/components/blog/comments/CommentForm.tsx
+++ b/src/components/blog/comments/CommentForm.tsx
@@ -6,23 +6,38 @@ import { createComment } from "@/lib/actions/comments";
 import { MAX_COMMENT_LENGTH } from "@/lib/constants";
 
 // 제출 중에는 useFormStatus로 pending을 감지해 버튼을 비활성화하고 라벨을 바꾼다.
-function SubmitButton() {
+function SubmitButton({ isReply }: { isReply: boolean }) {
   const { pending } = useFormStatus();
   return (
     <button
       type="submit"
       disabled={pending}
-      className="px-4 py-2 text-sm text-[var(--color-accent)] bg-[var(--color-bg)] hover:bg-[var(--color-muted)] border border-[var(--color-accent)]/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      className={`text-[var(--color-accent)] bg-[var(--color-bg)] hover:bg-[var(--color-muted)] border border-[var(--color-accent)]/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+        isReply ? "px-3 py-1 text-xs" : "px-4 py-2 text-sm"
+      }`}
     >
       {pending ? "등록 중…" : "등록"}
     </button>
   );
 }
 
-// 댓글 작성 폼(클라이언트). createComment(Server Action)를 호출하고,
+// 댓글/대댓글 작성 폼(클라이언트). createComment(Server Action)를 호출하고,
 // 성공하면 입력창과 글자 수 카운터를 비운다. 목록 갱신은 액션 내부의
-// revalidatePath가 담당한다.
-export default function CommentForm({ slug }: { slug: string }) {
+// revalidatePath가 담당한다. parentId가 있으면 대댓글 폼(터미널 스타일)으로 동작한다.
+export default function CommentForm({
+  slug,
+  parentId,
+  autoFocus = false,
+  onSuccess,
+  onCancel,
+}: {
+  slug: string;
+  parentId?: string;
+  autoFocus?: boolean;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}) {
+  const isReply = !!parentId;
   const formRef = useRef<HTMLFormElement>(null);
   const [count, setCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -48,37 +63,67 @@ export default function CommentForm({ slug }: { slug: string }) {
           formRef.current?.reset();
           setCount(0);
           setError(null);
+          onSuccess?.(); // 대댓글 폼은 성공 시 접힌다
         } catch {
-          setError("댓글 등록에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+          setError(
+            `${isReply ? "답글" : "댓글"} 등록에 실패했습니다. 잠시 후 다시 시도해 주세요.`,
+          );
         }
       }}
-      className="flex flex-col gap-3"
+      className="flex flex-col gap-2"
     >
       <input type="hidden" name="slug" value={slug} />
-      <textarea
-        name="content"
-        required
-        maxLength={MAX_COMMENT_LENGTH}
-        rows={3}
-        placeholder={`댓글을 입력하세요 (최대 ${MAX_COMMENT_LENGTH}자)`}
-        onChange={(e) => {
-          setCount(e.target.value.length);
-          if (error) setError(null); // 다시 입력하면 이전 오류를 지운다
-        }}
-        className="w-full resize-y bg-[var(--color-bg)] border border-[var(--color-muted)] p-3 text-sm text-[var(--color-secondary)] focus:outline-none focus:border-[var(--color-accent)] transition-colors"
-      />
+      {parentId && <input type="hidden" name="parentId" value={parentId} />}
+
+      {/* 답글 모드에서는 터미널 프롬프트처럼 '>' 프리픽스를 textarea 앞에 붙인다. */}
+      <div className={isReply ? "flex gap-2" : ""}>
+        {isReply && (
+          <span
+            aria-hidden
+            className="font-mono text-[var(--color-accent)] leading-none pt-3 select-none"
+          >
+            {">"}
+          </span>
+        )}
+        <textarea
+          name="content"
+          required
+          autoFocus={autoFocus}
+          maxLength={MAX_COMMENT_LENGTH}
+          rows={isReply ? 2 : 3}
+          placeholder={`${isReply ? "답글" : "댓글"}을 입력하세요 (최대 ${MAX_COMMENT_LENGTH}자)`}
+          onChange={(e) => {
+            setCount(e.target.value.length);
+            if (error) setError(null); // 다시 입력하면 이전 오류를 지운다
+          }}
+          className="w-full flex-1 resize-y bg-[var(--color-bg)] border border-[var(--color-muted)] p-3 text-sm text-[var(--color-secondary)] focus:outline-none focus:border-[var(--color-accent)] transition-colors"
+        />
+      </div>
+
       {error && (
-        <p role="alert" className="text-xs text-red-600 dark:text-red-400">
+        <p role="alert" className="text-xs text-[var(--color-error)]">
           {error}
         </p>
       )}
+
       <div className="flex items-center justify-between">
         <span
           className={`text-xs ${nearLimit ? "text-[var(--color-accent)] font-medium" : "text-[var(--color-secondary)]"}`}
         >
           {count}/{MAX_COMMENT_LENGTH}
         </span>
-        <SubmitButton />
+        <div className="flex items-center gap-2">
+          {isReply && onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-3 py-1 text-xs text-[var(--color-secondary)] hover:text-[var(--color-accent)] border border-transparent hover:border-[var(--color-muted)] transition-colors"
+            >
+              취소
+            </button>
+          )}
+          <SubmitButton isReply={isReply} />
+        </div>
       </div>
     </form>
   );

--- a/src/components/blog/comments/CommentItem.tsx
+++ b/src/components/blog/comments/CommentItem.tsx
@@ -1,44 +1,120 @@
 import Image from "next/image";
+import type { ReactNode } from "react";
 import DeleteButton from "./DeleteButton";
-import type { CommentWithAuthor } from "@/lib/data/comments";
+import ReplyThread from "./ReplyThread";
+import type { CommentWithAuthor, ReplyWithAuthor } from "@/lib/data/comments";
+
+// 본문에서 사용자가 직접 입력한 '@이름'만 멘션으로 강조한다(자동 삽입은 하지 않음).
+// 이메일(a@b.com) 등 오탐을 피하려고 앞이 공백이거나 문장 시작일 때만 인정한다.
+function renderContent(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const re = /@[^\s@]+/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const start = m.index;
+    const prevChar = start === 0 ? "" : text[start - 1];
+    if (start !== 0 && !/\s/.test(prevChar)) continue; // 단어 중간의 @는 멘션 아님
+    if (start > last) nodes.push(text.slice(last, start));
+    nodes.push(
+      <span key={key++} className="text-[var(--color-accent)] font-medium">
+        {m[0]}
+      </span>,
+    );
+    last = start + m[0].length;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
 
 interface CommentItemProps {
-  comment: CommentWithAuthor;
+  comment: CommentWithAuthor | ReplyWithAuthor;
   currentUserId?: string;
+  // 대댓글로 렌더될 때는 작은 아바타로 계층을 표시한다(들여쓰기는 ReplyThread가 담당, 중첩 1단계 제한).
+  isReply?: boolean;
 }
 
 // 댓글 1건. 본인 댓글에만 삭제 버튼을 노출한다(삭제는 서버에서 소유자 재검증).
-export default function CommentItem({ comment, currentUserId }: CommentItemProps) {
+// 최상위 댓글이면 로그인 시 답글 버튼(삭제 좌측)·대댓글 목록·작성 폼을 ReplyThread로 함께 렌더한다.
+export default function CommentItem({
+  comment,
+  currentUserId,
+  isReply = false,
+}: CommentItemProps) {
   const isOwner = !!currentUserId && comment.authorId === currentUserId;
+  const isLoggedIn = !!currentUserId;
+  // 대댓글 목록은 최상위 댓글에만 존재한다(타입 좁히기).
+  const replies = !isReply && "replies" in comment ? comment.replies : [];
+  const avatarSize = isReply ? 20 : 24;
   const createdAt = comment.createdAt.toLocaleDateString("ko-KR", {
     year: "numeric",
     month: "long",
     day: "numeric",
   });
 
+  // 아바타·이름·날짜 (최상위/대댓글 공통)
+  const headMeta = (
+    <>
+      {comment.author.image && (
+        <Image
+          src={comment.author.image}
+          alt={comment.author.name ?? "사용자"}
+          width={avatarSize}
+          height={avatarSize}
+          className="rounded-full border border-[var(--color-muted)] shrink-0"
+        />
+      )}
+      <span className="text-sm font-medium text-[var(--color-accent)] truncate">
+        {comment.author.name ?? "익명"}
+      </span>
+      <span className="text-xs text-[var(--color-secondary)] shrink-0">{createdAt}</span>
+    </>
+  );
+
+  const content = (
+    <p className="text-sm text-[var(--color-secondary)] whitespace-pre-wrap break-words">
+      {renderContent(comment.content)}
+    </p>
+  );
+
+  // 대댓글: 들여쓰기·좌측 가이드선은 상위 ReplyThread가 담당한다(글리프 미사용, 답글 버튼 없음).
+  if (isReply) {
+    return (
+      <li className="min-w-0">
+        <div className="flex items-center justify-between mb-1.5">
+          <div className="flex items-center gap-2 min-w-0">{headMeta}</div>
+          {isOwner && <DeleteButton id={comment.id} />}
+        </div>
+        {content}
+      </li>
+    );
+  }
+
+  // 최상위 댓글: 헤더(답글 버튼 + 삭제)·본문·대댓글 목록·작성 폼을 ReplyThread가 함께 렌더한다.
   return (
     <li className="py-4 border-b border-[var(--color-muted)] last:border-b-0">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          {comment.author.image && (
-            <Image
-              src={comment.author.image}
-              alt={comment.author.name ?? "사용자"}
-              width={24}
-              height={24}
-              className="rounded-full border border-[var(--color-muted)]"
-            />
-          )}
-          <span className="text-sm font-medium text-[var(--color-accent)]">
-            {comment.author.name ?? "익명"}
-          </span>
-          <span className="text-xs text-[var(--color-secondary)]">{createdAt}</span>
-        </div>
-        {isOwner && <DeleteButton id={comment.id} />}
-      </div>
-      <p className="text-sm text-[var(--color-secondary)] whitespace-pre-wrap break-words">
-        {comment.content}
-      </p>
+      <ReplyThread
+        slug={comment.postSlug}
+        parentId={comment.id}
+        canReply={isLoggedIn}
+        header={headMeta}
+        actions={isOwner ? <DeleteButton id={comment.id} /> : null}
+        content={content}
+      >
+        {replies.length > 0 && (
+          <ul className="flex flex-col gap-3">
+            {replies.map((reply) => (
+              <CommentItem
+                key={reply.id}
+                comment={reply}
+                currentUserId={currentUserId}
+                isReply
+              />
+            ))}
+          </ul>
+        )}
+      </ReplyThread>
     </li>
   );
 }

--- a/src/components/blog/comments/CommentItem.tsx
+++ b/src/components/blog/comments/CommentItem.tsx
@@ -15,14 +15,18 @@ function renderContent(text: string): ReactNode[] {
   while ((m = re.exec(text)) !== null) {
     const start = m.index;
     const prevChar = start === 0 ? "" : text[start - 1];
-    if (start !== 0 && !/\s/.test(prevChar)) continue; // 단어 중간의 @는 멘션 아님
+    if (start !== 0 && !/\s/.test(prevChar)) continue;
+
+    const mention = m[0].replace(/[^\p{L}\p{N}]+$/u, "");
+    if (mention.length <= 1) continue;
+
     if (start > last) nodes.push(text.slice(last, start));
     nodes.push(
       <span key={key++} className="text-[var(--color-accent)] font-medium">
-        {m[0]}
+        {mention}
       </span>,
     );
-    last = start + m[0].length;
+    last = start + mention.length;
   }
   if (last < text.length) nodes.push(text.slice(last));
   return nodes;
@@ -45,7 +49,8 @@ export default function CommentItem({
   const isOwner = !!currentUserId && comment.authorId === currentUserId;
   const isLoggedIn = !!currentUserId;
   // 대댓글 목록은 최상위 댓글에만 존재한다(타입 좁히기).
-  const replies = !isReply && "replies" in comment ? comment.replies : [];
+  const replies: ReplyWithAuthor[] =
+    !isReply && "replies" in comment ? comment.replies : [];
   const avatarSize = isReply ? 20 : 24;
   const createdAt = comment.createdAt.toLocaleDateString("ko-KR", {
     year: "numeric",
@@ -68,7 +73,9 @@ export default function CommentItem({
       <span className="text-sm font-medium text-[var(--color-accent)] truncate">
         {comment.author.name ?? "익명"}
       </span>
-      <span className="text-xs text-[var(--color-secondary)] shrink-0">{createdAt}</span>
+      <span className="text-xs text-[var(--color-secondary)] shrink-0">
+        {createdAt}
+      </span>
     </>
   );
 

--- a/src/components/blog/comments/DeleteButton.tsx
+++ b/src/components/blog/comments/DeleteButton.tsx
@@ -20,7 +20,7 @@ function SubmitButton() {
 // Server Action을 호출한다. id만 전달하고, 재검증 slug는 서버가 레코드에서 조회한다.
 export default function DeleteButton({ id }: { id: string }) {
   return (
-    <form action={deleteComment}>
+    <form action={deleteComment} className="contents">
       <input type="hidden" name="id" value={id} />
       <SubmitButton />
     </form>

--- a/src/components/blog/comments/ReplyThread.tsx
+++ b/src/components/blog/comments/ReplyThread.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import CommentForm from "./CommentForm";
+
+// 최상위 댓글의 헤더~답글 영역(클라이언트). 답글 버튼(헤더, 삭제 좌측)과
+// 작성 폼(스레드 하단)이 열림 상태를 공유해야 해서 한 컴포넌트로 감싼다.
+//  - header: 아바타·이름·날짜 (서버 렌더)
+//  - actions: 본인 댓글이면 삭제 버튼 (서버 렌더)
+//  - content: 본문 (서버 렌더, 멘션 강조 포함)
+//  - children: 대댓글 목록 (서버 렌더)
+// 대댓글·작성 폼은 좌측 가이드선으로 들여써 부모에 속함을 나타낸다(글리프 미사용).
+// 유일한 프롬프트 글리프는 작성 폼 내부의 '>' 프리픽스뿐이다.
+export default function ReplyThread({
+  slug,
+  parentId,
+  canReply,
+  header,
+  actions,
+  content,
+  children,
+}: {
+  slug: string;
+  parentId: string;
+  canReply: boolean;
+  header: ReactNode;
+  actions?: ReactNode;
+  content: ReactNode;
+  children?: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const hasThread = Boolean(children) || open;
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-1.5">
+        <div className="flex items-center gap-2 min-w-0">{header}</div>
+        <div className="flex items-center gap-3 shrink-0">
+          {canReply && (
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              className="text-xs text-[var(--color-secondary)] hover:text-[var(--color-accent)] underline-offset-2 hover:underline transition-colors"
+            >
+              답글
+            </button>
+          )}
+          {actions}
+        </div>
+      </div>
+
+      {content}
+
+      {hasThread && (
+        <div className="mt-2 pl-4 border-l border-[var(--color-muted)] flex flex-col gap-2">
+          {children}
+          {open && (
+            <CommentForm
+              slug={slug}
+              parentId={parentId}
+              autoFocus
+              onSuccess={() => setOpen(false)}
+              onCancel={() => setOpen(false)}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/common/footer.tsx
+++ b/src/components/common/footer.tsx
@@ -5,25 +5,9 @@ export default function Footer() {
     <footer className="w-full bg-[var(--color-bg)] text-[var(--color-secondary)] py-8">
       <div className="container mx-auto px-6">
         <div className="flex flex-col md:flex-row justify-between items-center">
-          {/* 저작권 */}
           <div className="mb-4 md:mb-0 text-center md:text-left">
             <p className="text-sm">
               © 2026 Chae Dahee&apos;s Tech Blog. All rights reserved.
-            </p>
-            <p className="text-xs text-[var(--color-secondary)] mt-1">
-              Built with Next.js &amp; TailwindCSS
-            </p>
-            <p className="text-xs text-[var(--color-secondary)] mt-1 opacity-60">
-              Ghost sprite by
-              <a
-                href="https://opengameart.org/users/pixerat"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-[var(--color-accent)]"
-              >
-                PiXeRaT
-            </a>
-              CC BY-SA 4.0
             </p>
           </div>
 

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -18,18 +18,23 @@ export async function createComment(formData: FormData) {
   });
   assertValidPostSlug(slug); // 임의 slug로 가짜 댓글이 쌓이는 것을 막는다
 
-  // 대댓글이면 부모가 같은 글의 '최상위' 댓글인지 검증한다.
-  // 위조된 parentId, 다른 글의 댓글, 대댓글에 다시 다는 2단계 이상 중첩을 막는다.
-  if (parentId) {
-    const parent = await prisma.comment.findUnique({ where: { id: parentId } });
-    if (!parent || parent.postSlug !== slug || parent.parentId !== null) {
-      throw new Error("invalid parent");
+  // 부모 검증과 대댓글 생성을 한 트랜잭션으로 묶는다. 대댓글이면 부모 행을
+  // FOR UPDATE로 잠가, 검증 직후 부모가 삭제되어 FK 위반으로 실패하는 경합을 없앤다.
+  await prisma.$transaction(async (tx) => {
+    if (parentId) {
+      // 부모가 같은 글의 '최상위' 댓글인지 검증(위조·타 글·2단계 이상 중첩 차단).
+      const [parent] = await tx.$queryRaw<
+        { postSlug: string; parentId: string | null }[]
+      >`SELECT "postSlug", "parentId" FROM "Comment" WHERE "id" = ${parentId} FOR UPDATE`;
+      if (!parent || parent.postSlug !== slug || parent.parentId !== null) {
+        throw new Error("invalid parent");
+      }
     }
-  }
 
-  await prisma.post.upsert({ where: { slug }, create: { slug }, update: {} }); // 앵커 보장
-  await prisma.comment.create({
-    data: { postSlug: slug, content, parentId, authorId: session.user.id },
+    await tx.post.upsert({ where: { slug }, create: { slug }, update: {} }); // 앵커 보장
+    await tx.comment.create({
+      data: { postSlug: slug, content, parentId, authorId: session.user.id },
+    });
   });
   revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
 }

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -11,15 +11,25 @@ export async function createComment(formData: FormData) {
   const session = await auth();
   if (!session?.user?.id) throw new Error("unauthorized"); // 서버단 1차 방어
 
-  const { slug, content } = CommentSchema.parse({
+  const { slug, content, parentId } = CommentSchema.parse({
     slug: formData.get("slug"),
     content: formData.get("content"),
+    parentId: formData.get("parentId") || undefined,
   });
   assertValidPostSlug(slug); // 임의 slug로 가짜 댓글이 쌓이는 것을 막는다
 
+  // 대댓글이면 부모가 같은 글의 '최상위' 댓글인지 검증한다.
+  // 위조된 parentId, 다른 글의 댓글, 대댓글에 다시 다는 2단계 이상 중첩을 막는다.
+  if (parentId) {
+    const parent = await prisma.comment.findUnique({ where: { id: parentId } });
+    if (!parent || parent.postSlug !== slug || parent.parentId !== null) {
+      throw new Error("invalid parent");
+    }
+  }
+
   await prisma.post.upsert({ where: { slug }, create: { slug }, update: {} }); // 앵커 보장
   await prisma.comment.create({
-    data: { postSlug: slug, content, authorId: session.user.id },
+    data: { postSlug: slug, content, parentId, authorId: session.user.id },
   });
   revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
 }

--- a/src/lib/data/comments.ts
+++ b/src/lib/data/comments.ts
@@ -1,13 +1,21 @@
 import { prisma } from "@/lib/prisma";
 
 // 글의 최상위 댓글 목록을 최신순으로 조회한다(작성자 정보 포함).
-// 대댓글(replies)은 스키마상 준비돼 있으나 작성 UI는 후속 단계에서 다룬다.
+// 각 댓글의 대댓글(replies)은 작성자 정보와 함께 오래된 순으로 붙여 온다. 중첩은 1단계로 제한한다.
 export async function getComments(slug: string) {
   return prisma.comment.findMany({
     where: { postSlug: slug, parentId: null },
-    include: { author: true },
+    include: {
+      author: true,
+      replies: {
+        include: { author: true },
+        orderBy: { createdAt: "asc" },
+      },
+    },
     orderBy: { createdAt: "desc" },
   });
 }
 
+// 최상위 댓글(대댓글 목록 포함)과 대댓글 1건의 타입.
 export type CommentWithAuthor = Awaited<ReturnType<typeof getComments>>[number];
+export type ReplyWithAuthor = CommentWithAuthor["replies"][number];

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -11,4 +11,6 @@ export const CommentSchema = z.object({
     .trim()
     .min(1, "내용을 입력해 주세요.")
     .max(MAX_COMMENT_LENGTH, `${MAX_COMMENT_LENGTH}자 이내로 입력해 주세요.`),
+  // 대댓글이면 부모 댓글 id. 최상위 댓글이면 없음.
+  parentId: z.string().min(1).optional(),
 });

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -12,4 +12,5 @@ module.exports = {
   textDark: "#22c55e", // terminal green
   terminal: "#22c55e",
   onAccent: "#111827", // accent(초록) 배경 위의 전경색
+  error: "#f87171", // 다크 배경 위 오류
 };

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -6,6 +6,7 @@
     --color-secondary: #374151;
     --color-accent: #15803d;
     --color-muted: #d1d5db;
+    --color-error: #dc2626;
 
     /* Font families */
     --font-sans: theme('fontFamily.sans');
@@ -20,4 +21,5 @@
     --color-secondary: theme('colors.textLight');
     --color-accent: theme('colors.terminal');
     --color-muted: theme('colors.light');
+    --color-error: theme('colors.error');
 }


### PR DESCRIPTION
## 배경 및 목적

- 댓글 작성·삭제는 이미 제공 중입니다. 여기에 **답글(대댓글)** 을 더해 하나의 댓글에 이어지는 맥락 있는 대화를 지원합니다.
- 더불어 오류 문구 색을 **디자인 토큰으로 통일**해 라이트/다크 테마 일관성을 확보합니다.

## 설계

- **중첩 1단계 제한**을 데이터·검증·UI 세 계층에서 일관 보장
  - 데이터: `getComments`가 최상위 댓글의 `replies`를 1레벨만 조회
  - 검증: `createComment`는 부모가 **같은 글의 최상위 댓글**일 때만 대댓글 허용
  - UI: 대댓글에는 답글 버튼을 노출하지 않음
- **정렬**: 최상위 댓글은 최신순(desc), 답글은 시간순(asc) — 스레드 가독성
- **상태 관리**: 답글 버튼(헤더)과 작성 폼(스레드 하단)이 열림 상태를 공유해야 하므로 `ReplyThread`(클라이언트)가 헤더~답글 영역을 함께 감쌈
- **스타일**: 사이트의 미니멀 톤 유지. 계층은 글리프 없이 **들여쓰기 + 좌측 가이드선**으로 표현하고, 작성 폼 앞의 `>` 프롬프트만 남김
- **멘션**: 자동 삽입 없이, 사용자가 **직접 입력한 `@이름`만** 강조(이메일 등 오탐 방지)
- **오류 색 토큰**: `--color-error` 신설(라이트 `#dc2626` / 다크 `#f87171`)

## 구현 내용

- `lib/data/comments.ts` — `replies`(작성자 포함, 시간순) 함께 조회, `ReplyWithAuthor` 타입
- `lib/schemas.ts` — `CommentSchema.parentId` 추가
- `lib/actions/comments.ts` — `createComment`가 `parentId` 저장 + 부모 유효성 검증
- `components/blog/comments/ReplyThread.tsx` (신규) — 답글 버튼·목록·작성 폼 상태 통합 관리
- `components/blog/comments/CommentForm.tsx` — 답글 모드(`>` 프롬프트·인라인 취소/등록), 오류색 토큰화
- `components/blog/comments/CommentItem.tsx` — 대댓글 렌더·멘션 강조 파서
- `components/blog/comments/DeleteButton.tsx` — form에 `display:contents`로 답글 버튼과 정렬 기준 일치
- `styles/colors.js`·`styles/tokens.css` — `--color-error` 토큰
- `components/common/footer.tsx` — 부가 문구 정리(댓글과 무관, 별도 커밋)

## 코드 리뷰 포인트

- `createComment` 부모 검증: 위조 `parentId`·타 글 참조·2단계 이상 중첩을 모두 차단하는지
- 멘션 파서: `@` 앞이 공백/문장 시작일 때만 인정(이메일 `a@b.com` 오탐 방지)
- `DeleteButton`의 `display:contents` — 폼 동작·접근성 영향 없이 정렬만 정렬되는지
- **footer 변경 주의**: Ghost 스프라이트는 CC BY-SA로 저작자 표기 의무가 있어, 표기 제거가 라이선스상 문제되지 않는지 확인 필요

## 사이드이펙트 검토

- 기존 댓글 작성·삭제 동작은 그대로 유지, 대댓글은 추가 기능으로만 동작
- DB 마이그레이션 불필요 — 스키마에 `parentId`·자기참조·인덱스가 이미 존재

- [x] 기존 사용자 breaking 없음
- [x] 외부 파일·설정 파싱 관련 변경 없음 (해당 없음)
- [x] 연관 커맨드·스크립트 동작 변화 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 댓글/답글을 하나의 입력 폼에서 작성할 수 있게 되었습니다.
  * 답글 스레드가 표시되고, 답글 버튼으로 바로 입력을 열 수 있습니다.
  * 답글 모드에서 입력창 안내(자동 포커스/형식)와 취소 동작이 추가되었습니다.
* **Bug Fixes**
  * 답글이 올바른 댓글에만 연결되도록 생성 전 검증이 강화되었습니다.
  * 멘션 표기(문장 시작/공백 뒤) 강조 규칙이 개선되었습니다.
  * 답글이 오래된 순서부터 자연스럽게 정렬되어 표시됩니다.
* **Style/Chores**
  * 오류 색상과 관련 UI 표시가 일관되게 조정되었고, 푸터 저작권 문구가 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->