### PR TITLE
feat: 댓글 도배 방지(rate limit) 추가

### DIFF
--- a/src/components/blog/comments/CommentForm.tsx
+++ b/src/components/blog/comments/CommentForm.tsx
@@ -56,10 +56,13 @@ export default function CommentForm({
           return;
         }
 
-        // createComment는 인증·slug·스키마 검증 실패 시 예외를 던진다.
-        // 성공했을 때만 입력창을 비우고, 실패하면 입력을 유지한 채 오류를 알린다.
+        // createComment는 도배 방지는 반환값으로, 그 외 실패는 예외로 알린다.
         try {
-          await createComment(formData);
+          const result = await createComment(formData);
+          if (result?.ok === false) {
+            setError(`${result.retryAfterSec}초 후 다시 작성할 수 있어요.`);
+            return;
+          }
           formRef.current?.reset();
           setCount(0);
           setError(null);

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -20,6 +20,7 @@ export type CreateCommentResult =
 export async function createComment(formData: FormData): Promise<CreateCommentResult> {
   const session = await auth();
   if (!session?.user?.id) throw new Error("unauthorized"); // 서버단 1차 방어
+  const authorId = session.user.id;
 
   const { slug, content, parentId } = CommentSchema.parse({
     slug: formData.get("slug"),
@@ -28,17 +29,20 @@ export async function createComment(formData: FormData): Promise<CreateCommentRe
   });
   assertValidPostSlug(slug); // 임의 slug로 가짜 댓글이 쌓이는 것을 막는다
 
-  // 유효한 입력에만 판정해, 검증 오류가 대기 안내로 가려지지 않게 한다
-  const rateLimit = await getCommentRateLimitStatus(session.user.id);
-  if (!rateLimit.ok) {
-    return { ok: false, error: "rate_limited", retryAfterSec: rateLimit.retryAfterSec };
-  }
+  // 도배 판정과 생성을 같은 트랜잭션에서 작성자 단위로 직렬화한다.
+  // 잠금이 없으면 병렬 요청이 판정을 동시에 통과해 15초/5분 제한이 뚫린다.
+  const result = await prisma.$transaction(async (tx): Promise<CreateCommentResult> => {
+    // 작성자 키 잠금(트랜잭션 종료 시 자동 해제). 같은 작성자의 다른 요청은 여기서 대기한다.
+    await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${authorId}))`;
 
-  // 부모 검증과 대댓글 생성을 한 트랜잭션으로 묶는다. 대댓글이면 부모 행을
-  // FOR UPDATE로 잠가, 검증 직후 부모가 삭제되어 FK 위반으로 실패하는 경합을 없앤다.
-  await prisma.$transaction(async (tx) => {
+    const rateLimit = await getCommentRateLimitStatus(authorId, tx);
+    if (!rateLimit.ok) {
+      return { ok: false, error: "rate_limited", retryAfterSec: rateLimit.retryAfterSec };
+    }
+
     if (parentId) {
       // 부모가 같은 글의 '최상위' 댓글인지 검증(위조·타 글·2단계 이상 중첩 차단).
+      // FOR UPDATE로 잠가, 검증 직후 부모가 삭제되어 FK 위반으로 실패하는 경합을 없앤다.
       const [parent] = await tx.$queryRaw<
         { postSlug: string; parentId: string | null }[]
       >`SELECT "postSlug", "parentId" FROM "Comment" WHERE "id" = ${parentId} FOR UPDATE`;
@@ -49,11 +53,13 @@ export async function createComment(formData: FormData): Promise<CreateCommentRe
 
     await tx.post.upsert({ where: { slug }, create: { slug }, update: {} }); // 앵커 보장
     await tx.comment.create({
-      data: { postSlug: slug, content, parentId, authorId: session.user.id },
+      data: { postSlug: slug, content, parentId, authorId },
     });
+    return { ok: true };
   });
-  revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
-  return { ok: true };
+
+  if (result.ok) revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
+  return result;
 }
 
 // 댓글 삭제. 본인 댓글만 삭제할 수 있다. 폼의 hidden input으로 id만 받는다.

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -33,7 +33,8 @@ export async function createComment(formData: FormData): Promise<CreateCommentRe
   // 잠금이 없으면 병렬 요청이 판정을 동시에 통과해 15초/5분 제한이 뚫린다.
   const result = await prisma.$transaction(async (tx): Promise<CreateCommentResult> => {
     // 작성자 키 잠금(트랜잭션 종료 시 자동 해제). 같은 작성자의 다른 요청은 여기서 대기한다.
-    await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${authorId}))`;
+    // 반환 타입이 void라 $queryRaw는 역직렬화에 실패하므로 $executeRaw를 쓴다.
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${authorId}))`;
 
     const rateLimit = await getCommentRateLimitStatus(authorId, tx);
     if (!rateLimit.ok) {

--- a/src/lib/actions/comments.ts
+++ b/src/lib/actions/comments.ts
@@ -5,9 +5,19 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { CommentSchema } from "@/lib/schemas";
 import { assertValidPostSlug } from "@/lib/data/posts";
+import { getCommentRateLimitStatus } from "@/lib/data/comments";
 
-// 댓글 작성. 로그인 사용자만 가능하며, 실제 글 slug만 허용한다.
-export async function createComment(formData: FormData) {
+export type CreateCommentResult =
+  | { ok: true }
+  | { ok: false; error: "rate_limited"; retryAfterSec: number };
+
+/**
+ * 댓글 작성. 로그인 사용자만 가능하며, 실제 글 slug만 허용한다.
+ *
+ * 도배 방지(rate_limited)는 예상된 거부라 반환값으로 알리고,
+ * 그 외 실패(인증·검증)는 예외로 던진다.
+ */
+export async function createComment(formData: FormData): Promise<CreateCommentResult> {
   const session = await auth();
   if (!session?.user?.id) throw new Error("unauthorized"); // 서버단 1차 방어
 
@@ -17,6 +27,12 @@ export async function createComment(formData: FormData) {
     parentId: formData.get("parentId") || undefined,
   });
   assertValidPostSlug(slug); // 임의 slug로 가짜 댓글이 쌓이는 것을 막는다
+
+  // 유효한 입력에만 판정해, 검증 오류가 대기 안내로 가려지지 않게 한다
+  const rateLimit = await getCommentRateLimitStatus(session.user.id);
+  if (!rateLimit.ok) {
+    return { ok: false, error: "rate_limited", retryAfterSec: rateLimit.retryAfterSec };
+  }
 
   // 부모 검증과 대댓글 생성을 한 트랜잭션으로 묶는다. 대댓글이면 부모 행을
   // FOR UPDATE로 잠가, 검증 직후 부모가 삭제되어 FK 위반으로 실패하는 경합을 없앤다.
@@ -37,6 +53,7 @@ export async function createComment(formData: FormData) {
     });
   });
   revalidatePath(`/blog/${slug}`); // 목록 즉시 갱신
+  return { ok: true };
 }
 
 // 댓글 삭제. 본인 댓글만 삭제할 수 있다. 폼의 hidden input으로 id만 받는다.

--- a/src/lib/data/comments.ts
+++ b/src/lib/data/comments.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
 /** 댓글 도배 방지 정책(authorId 단위). 간격 미달·버스트 초과 중 하나만 걸려도 차단한다. */
@@ -30,12 +31,17 @@ export type RateLimitStatus = { ok: true } | { ok: false; retryAfterSec: number 
 /**
  * 댓글 도배 방지 판정. 최신 댓글 조회 한 번으로
  * 최소 간격과 버스트 상한을 함께 검사한다.
+ *
+ * 판정과 생성을 원자적으로 묶으려면 호출자의 트랜잭션(tx)을 db로 넘긴다.
  */
-export async function getCommentRateLimitStatus(authorId: string): Promise<RateLimitStatus> {
+export async function getCommentRateLimitStatus(
+  authorId: string,
+  db: Prisma.TransactionClient = prisma,
+): Promise<RateLimitStatus> {
   const now = Date.now();
   // 두 정책 중 긴 창 기준으로 조회해, 상수를 조정해도 간격 검사가 누락되지 않게 한다
   const windowSec = Math.max(COMMENT_MIN_INTERVAL_SEC, COMMENT_BURST_WINDOW_SEC);
-  const recent = await prisma.comment.findMany({
+  const recent = await db.comment.findMany({
     where: { authorId, createdAt: { gte: new Date(now - windowSec * 1000) } },
     orderBy: { createdAt: "desc" },
     select: { createdAt: true },

--- a/src/lib/data/comments.ts
+++ b/src/lib/data/comments.ts
@@ -1,5 +1,10 @@
 import { prisma } from "@/lib/prisma";
 
+/** 댓글 도배 방지 정책(authorId 단위). 간격 미달·버스트 초과 중 하나만 걸려도 차단한다. */
+const COMMENT_MIN_INTERVAL_SEC = 15;
+const COMMENT_BURST_LIMIT = 5;
+const COMMENT_BURST_WINDOW_SEC = 300;
+
 // 글의 최상위 댓글 목록을 최신순으로 조회한다(작성자 정보 포함).
 // 각 댓글의 대댓글(replies)은 작성자 정보와 함께 오래된 순으로 붙여 온다. 중첩은 1단계로 제한한다.
 export async function getComments(slug: string) {
@@ -19,3 +24,39 @@ export async function getComments(slug: string) {
 // 최상위 댓글(대댓글 목록 포함)과 대댓글 1건의 타입.
 export type CommentWithAuthor = Awaited<ReturnType<typeof getComments>>[number];
 export type ReplyWithAuthor = CommentWithAuthor["replies"][number];
+
+export type RateLimitStatus = { ok: true } | { ok: false; retryAfterSec: number };
+
+/**
+ * 댓글 도배 방지 판정. 최신 댓글 조회 한 번으로
+ * 최소 간격과 버스트 상한을 함께 검사한다.
+ */
+export async function getCommentRateLimitStatus(authorId: string): Promise<RateLimitStatus> {
+  const now = Date.now();
+  // 두 정책 중 긴 창 기준으로 조회해, 상수를 조정해도 간격 검사가 누락되지 않게 한다
+  const windowSec = Math.max(COMMENT_MIN_INTERVAL_SEC, COMMENT_BURST_WINDOW_SEC);
+  const recent = await prisma.comment.findMany({
+    where: { authorId, createdAt: { gte: new Date(now - windowSec * 1000) } },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+    take: COMMENT_BURST_LIMIT, // 판정에는 최신 LIMIT건이면 충분
+  });
+
+  let retryAfterSec = 0;
+
+  if (recent.length > 0) {
+    const sinceLastSec = (now - recent[0].createdAt.getTime()) / 1000;
+    if (sinceLastSec < COMMENT_MIN_INTERVAL_SEC) {
+      retryAfterSec = Math.ceil(COMMENT_MIN_INTERVAL_SEC - sinceLastSec);
+    }
+  }
+
+  // LIMIT번째로 최신인 댓글이 버스트 창을 벗어나야 상한 아래로 내려간다
+  if (recent.length >= COMMENT_BURST_LIMIT) {
+    const pivotMs = recent[COMMENT_BURST_LIMIT - 1].createdAt.getTime();
+    const waitSec = Math.ceil((pivotMs + COMMENT_BURST_WINDOW_SEC * 1000 - now) / 1000);
+    if (waitSec > 0) retryAfterSec = Math.max(retryAfterSec, waitSec);
+  }
+
+  return retryAfterSec > 0 ? { ok: false, retryAfterSec } : { ok: true };
+}


### PR DESCRIPTION
## 배경 및 목적

- M5(다듬기) 첫 항목으로 댓글 도배 방지 도입
- 댓글 기능에 작성 빈도 상한을 더해 스팸·도배로부터 목록 품질과 운영 안정성 확보
- 제한에 걸린 사용자에게 남은 대기 시간을 안내해, 차단이 아닌 "잠시 후 재시도" 경험 제공

## 설계

- **정책**: 로그인 사용자(authorId) 단위, ①최소 간격 15초 + ②최근 5분간 5건 상한. 둘 중 하나라도 걸리면 차단
- **저장소**: 신규 인프라(Vercel KV·Upstash) 없이 기존 `Comment` 테이블 + `@@index([authorId])`만 사용. 창 내 최신 댓글 최대 5건을 한 번 조회해 두 정책을 동시 판정
- **전달 방식**: rate limit은 예상된 소프트 거부 → throw 대신 반환값(`CreateCommentResult`)으로 전달. 프로덕션에서 Server Action의 throw 메시지가 마스킹되어 `retryAfterSec`를 실을 수 없기 때문. 인증·검증 실패는 기존대로 throw 유지
- **판정 위치**: 입력 검증(zod·slug) 통과 후, **생성과 같은 트랜잭션 안** → 검증 오류가 대기 안내로 가려지지 않고, 판정·생성이 원자적
- **동시성(리뷰 반영)**: 트랜잭션 첫 문장에서 `pg_advisory_xact_lock(hashtext(authorId))`로 작성자 단위 직렬화. 병렬 요청 N건이 같은 창 상태를 읽고 모두 통과하는 check-then-act 경합 제거. 잠금은 트랜잭션 종료 시 자동 해제, 스키마 변경(별도 quota row) 불필요
- **버스트 대기 기준점**: 가장 오래된 댓글이 아닌 **LIMIT번째로 최신인 댓글**이 창을 벗어나는 시점. 그 순간 창 내 건수가 처음으로 상한 아래로 내려가므로, 안내된 시간만 기다리면 반드시 통과

## 구현 내용

- `src/lib/data/comments.ts` — 정책 상수 3개(서버 전용이라 클라이언트 공유용 constants.ts 대신 소비처에 배치) + `getCommentRateLimitStatus` 판정 함수 추가. 호출자의 트랜잭션(tx)을 `db` 파라미터로 받아 원자적 판정 지원
- `src/lib/actions/comments.ts` — `createComment` 반환 타입을 `CreateCommentResult` 판별 유니온으로 변경. 트랜잭션 안에서 작성자 잠금 → 판정 → 부모 검증 → 생성 순으로 수행
- `src/components/blog/comments/CommentForm.tsx` — 제한 시 "N초 후 다시 작성할 수 있어요." 표시, 입력 내용 유지(리셋 안 함)

## 코드 리뷰 포인트

- **작성자 잠금 방식**: `pg_advisory_xact_lock(hashtext(authorId))` — `hashtext` 해시 충돌 시 서로 다른 작성자가 잠시 직렬화될 수 있으나 정합성에는 무해. 별도 quota row 대비 스키마 변경 없이 동일한 보장 확보
- **잠금 대기 시간**: 같은 작성자의 요청만 직렬화되므로 병목은 사용자 자신에게 한정. Prisma 트랜잭션 기본 타임아웃(5초) 초과 시 예외 → 폼의 일반 오류 문구로 처리
- **시계 기준**: 판정은 앱 서버 `Date.now()` vs DB `createdAt` 비교. Vercel·Neon 모두 NTP 동기화 환경이라 실질 오차 미미로 판단
- 조회 창을 `Math.max(MIN_INTERVAL, BURST_WINDOW)`로 계산 — 추후 상수 조정 시 간격 검사가 조용히 무력화되는 것 방지

## 사이드이펙트 검토

- `createComment` 반환 타입 변경(`void` → `CreateCommentResult`): 호출부는 `CommentForm` 한 곳뿐이며 함께 수정됨
- 폼은 `result?.ok === false`로 분기 — 구버전 액션(void 반환)과 겹치는 배포 순간에도 안전
- 스키마·마이그레이션·환경변수 변경 없음

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리 — 해당 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `tsc --noEmit`·`next lint` 통과
- 수동 검증 절차: 댓글 작성 직후 재작성 → "N초 후..." 안내·입력 유지 / 15초 경과 후 성공 / 5분 내 5건 후 6번째 차단(대댓글 합산) / 타 계정은 카운트 독립

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 댓글 작성 시 작성자 기준 도배 방지 제한이 적용되며, 제한 발생 시 재작성 가능까지의 예상 대기 시간을 함께 안내합니다.
  - 최소 간격 및 짧은 시간 내 버스트 한도를 함께 반영해 제어합니다.
- **Bug Fixes**
  - 댓글 제출 실패 시 원인에 따라 메시지를 분기해 표시하며(대기 시간 포함), 성공 시에는 기존과 동일하게 입력 초기화 및 후속 처리 흐름이 정상 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->