### PR TITLE
feat: 조회수 중복 집계 방지(IP+slug, 1시간)

### DIFF
--- a/prisma/migrations/20260702090000_add_view_log/migration.sql
+++ b/prisma/migrations/20260702090000_add_view_log/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "ViewLog" (
+    "postSlug" TEXT NOT NULL,
+    "visitorHash" TEXT NOT NULL,
+    "lastViewedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ViewLog_pkey" PRIMARY KEY ("postSlug","visitorHash")
+);
+
+-- AddForeignKey
+ALTER TABLE "ViewLog" ADD CONSTRAINT "ViewLog_postSlug_fkey" FOREIGN KEY ("postSlug") REFERENCES "Post"("slug") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,7 @@
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL") // 풀링된 연결 (런타임용)
-  directUrl = env("DIRECT_URL")   // 직접 연결 (마이그레이션용)
+  directUrl = env("DIRECT_URL") // 직접 연결 (마이그레이션용)
 }
 
 generator client {
@@ -10,10 +10,21 @@ generator client {
 
 // 글: 본문은 마크다운 파일, DB엔 동적 데이터의 앵커(slug)만 둔다
 model Post {
-  slug      String   @id
-  viewCount Int      @default(0)
+  slug      String    @id
+  viewCount Int       @default(0)
   comments  Comment[]
-  createdAt DateTime @default(now())
+  viewLogs  ViewLog[]
+  createdAt DateTime  @default(now())
+}
+
+// 동일 IP(원문이 아닌 HMAC 해시)·글 조합의 마지막 조회수 집계 시각.
+model ViewLog {
+  postSlug     String
+  visitorHash  String
+  lastViewedAt DateTime @default(now())
+  post         Post     @relation(fields: [postSlug], references: [slug], onDelete: Cascade)
+
+  @@id([postSlug, visitorHash])
 }
 
 model Comment {

--- a/src/lib/actions/views.ts
+++ b/src/lib/actions/views.ts
@@ -1,10 +1,28 @@
 "use server";
 
+import { createHmac } from "node:crypto";
+import { headers } from "next/headers";
 import { incrementViewCount } from "@/lib/data/posts";
 
-// 클라이언트에서 호출하는 쓰기 진입점. 진입 시 조회수 +1 후 갱신된 값을 돌려준다.
+function getVisitorHash() {
+  const requestHeaders = headers();
+  const forwardedFor =
+    requestHeaders.get("x-vercel-forwarded-for") ??
+    requestHeaders.get("x-forwarded-for") ??
+    requestHeaders.get("x-real-ip");
+  const ip = forwardedFor?.split(",")[0]?.trim();
+  if (!ip) throw new Error("Unable to determine visitor IP");
+
+  const secret = process.env.VIEW_HASH_SECRET;
+  if (!secret) throw new Error("VIEW_HASH_SECRET is not configured");
+
+  return createHmac("sha256", secret).update(ip).digest("hex");
+}
+
+// 클라이언트에서 호출하는 쓰기 진입점. 동일 IP·글은 1시간에 한 번만 집계하고
+// 집계 여부와 무관하게 현재 확정 조회수를 돌려준다.
 // slug 검증은 incrementViewCount 내부(assertValidPostSlug)에서 수행하므로
 // 임의 문자열로 가짜 레코드를 만들 수 없다.
 export async function bumpView(slug: string) {
-  return incrementViewCount(slug);
+  return incrementViewCount(slug, getVisitorHash());
 }

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -9,8 +9,6 @@ export function assertValidPostSlug(slug: string) {
   }
 }
 
-const VIEW_DEDUP_WINDOW_MS = 60 * 60 * 1000;
-
 // 동일 방문자(IP HMAC 해시)·글 조합은 마지막 집계 후 1시간이 지나야 다시 집계한다.
 // ViewLog 조건부 upsert와 조회수 증가는 한 트랜잭션에서 처리해 동시 요청의 중복 증가를 막는다.
 export async function incrementViewCount(slug: string, visitorHash: string) {
@@ -23,13 +21,12 @@ export async function incrementViewCount(slug: string, visitorHash: string) {
       update: {},
     });
 
-    const cutoff = new Date(Date.now() - VIEW_DEDUP_WINDOW_MS);
     const accepted = await tx.$queryRaw<{ accepted: number }[]>`
       INSERT INTO "ViewLog" ("postSlug", "visitorHash", "lastViewedAt")
       VALUES (${slug}, ${visitorHash}, NOW())
       ON CONFLICT ("postSlug", "visitorHash")
       DO UPDATE SET "lastViewedAt" = EXCLUDED."lastViewedAt"
-      WHERE "ViewLog"."lastViewedAt" <= ${cutoff}
+      WHERE "ViewLog"."lastViewedAt" <= NOW() - INTERVAL '1 hour'
       RETURNING 1 AS "accepted"
     `;
 

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -9,14 +9,43 @@ export function assertValidPostSlug(slug: string) {
   }
 }
 
-// 조회수를 1 올린다. 레코드가 없으면 생성하면서 1로 시작.
-export async function incrementViewCount(slug: string) {
+const VIEW_DEDUP_WINDOW_MS = 60 * 60 * 1000;
+
+// 동일 방문자(IP HMAC 해시)·글 조합은 마지막 집계 후 1시간이 지나야 다시 집계한다.
+// ViewLog 조건부 upsert와 조회수 증가는 한 트랜잭션에서 처리해 동시 요청의 중복 증가를 막는다.
+export async function incrementViewCount(slug: string, visitorHash: string) {
   assertValidPostSlug(slug);
 
-  const post = await prisma.post.upsert({
-    where: { slug },
-    create: { slug, viewCount: 1 }, // 글 앵커가 없으면 생성
-    update: { viewCount: { increment: 1 } }, // increment = 원자적 +1
+  return prisma.$transaction(async (tx) => {
+    await tx.post.upsert({
+      where: { slug },
+      create: { slug },
+      update: {},
+    });
+
+    const cutoff = new Date(Date.now() - VIEW_DEDUP_WINDOW_MS);
+    const accepted = await tx.$queryRaw<{ accepted: number }[]>`
+      INSERT INTO "ViewLog" ("postSlug", "visitorHash", "lastViewedAt")
+      VALUES (${slug}, ${visitorHash}, NOW())
+      ON CONFLICT ("postSlug", "visitorHash")
+      DO UPDATE SET "lastViewedAt" = EXCLUDED."lastViewedAt"
+      WHERE "ViewLog"."lastViewedAt" <= ${cutoff}
+      RETURNING 1 AS "accepted"
+    `;
+
+    if (accepted.length > 0) {
+      const post = await tx.post.update({
+        where: { slug },
+        data: { viewCount: { increment: 1 } },
+        select: { viewCount: true },
+      });
+      return post.viewCount;
+    }
+
+    const post = await tx.post.findUniqueOrThrow({
+      where: { slug },
+      select: { viewCount: true },
+    });
+    return post.viewCount;
   });
-  return post.viewCount;
 }


### PR DESCRIPTION
## 배경 및 목적

- 글 진입 시 증가하는 조회수에 **동일 방문자 중복 집계 방지**를 추가합니다.
- 동일 IP가 같은 글을 반복 방문하면 마지막 집계 후 1시간에 한 번만 반영해 조회수의 유효성을 높입니다.
- 서로 다른 IP의 방문과 동일 IP의 다른 글 방문은 독립적으로 집계합니다.

## 설계

- **방문자 식별**: Vercel 요청 헤더의 IP를 `HMAC-SHA256(VIEW_HASH_SECRET, IP)`로 해시해 사용. 원본 IP는 저장하지 않습니다.
- **집계 단위**: `postSlug + visitorHash`를 `ViewLog` 복합 기본키로 사용하고 마지막 집계 시각(`lastViewedAt`)을 저장합니다.
- **제한 방식**: PostgreSQL의 `NOW()`를 기준으로 마지막 집계 시각부터 1시간을 계산하는 rolling window를 적용합니다.
- **동시성**: PostgreSQL 조건부 upsert와 `Post.viewCount` 증가를 같은 트랜잭션에서 처리합니다. 같은 방문자의 병렬 요청도 한 번만 집계됩니다.
- **관계 정리**: `ViewLog.postSlug`가 `Post.slug`를 참조하며, 글 삭제 시 관련 로그도 cascade 삭제됩니다.

## 구현 내용

- `prisma/schema.prisma` — `ViewLog` 모델·복합 기본키와 `Post.viewLogs` 관계 추가.
- `prisma/migrations/20260702090000_add_view_log/migration.sql` — `ViewLog` 테이블과 `Post.slug` 외래 키 생성.
- `src/lib/actions/views.ts` — Vercel 요청 헤더에서 IP를 읽고 `VIEW_HASH_SECRET`으로 HMAC 해시 생성.
- `src/lib/data/posts.ts` — 기록이 없거나 마지막 집계 후 1시간이 지난 경우에만 조회수를 증가시키는 조건부 upsert 추가.
- `ViewCounter`는 기존과 동일하게 Server Action이 반환한 최신 확정 조회수를 표시합니다.

## 코드 리뷰 포인트

- **1시간 기준**: 차단된 재방문에서는 `lastViewedAt`을 갱신하지 않습니다. 반복 방문으로 제한 시간이 계속 연장되지 않습니다.
- **시계 기준**: 저장과 cutoff 판정 모두 PostgreSQL `NOW()`를 사용해 앱 서버와 DB의 시계 차이를 배제합니다.
- **조건부 증가**: `ViewLog` insert/update가 성공해 행을 반환한 경우에만 `viewCount`가 증가합니다.
- **IP 헤더 우선순위**: `x-vercel-forwarded-for` → `x-forwarded-for` → `x-real-ip` 순으로 확인합니다.
- **환경변수 누락**: IP 또는 `VIEW_HASH_SECRET`을 확인할 수 없으면 집계하지 않고 명시적으로 실패합니다. `ViewCounter`는 기존 오류 처리에 따라 `— views`를 유지합니다.

## 사이드이펙트 검토

- 배포 시 **DB 마이그레이션 적용 필요**(`prisma migrate deploy`). 신규 테이블 추가라 기존 `Post.viewCount` 데이터는 유지됩니다.
- Vercel 환경변수에 **`VIEW_HASH_SECRET` 등록 필요**. 값을 변경하면 기존 방문자 해시와 달라져 변경 후 첫 방문이 다시 집계됩니다.
- 동일 공인 IP를 공유하는 사용자는 같은 방문자로 처리됩니다.

- [x] 기존 사용자 breaking 없음 (기존 조회수 데이터 유지)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리 (`VIEW_HASH_SECRET` 누락 시 명시적 실패)
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `yarn prisma format`·`yarn prisma validate`·`yarn prisma generate` 통과
- `yarn tsc --noEmit`·`yarn lint` 통과
- `yarn build` 통과
- 마이그레이션 적용 후 수동 확인 권장: 같은 IP·같은 글 1시간 내 재방문 미증가 / 다른 IP 또는 다른 글 독립 증가 / 1시간 경과 후 재증가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 게시글 조회 이력을 추가해 동일 방문자 기준(해시 기반)으로 조회수가 중복 집계되지 않도록 개선되었습니다.
  * 같은 방문자의 반복 조회는 일정 시간 간격(1시간) 내에는 한 번만 반영되어 조회 집계가 더 정교해졌습니다.
* **Bug Fixes**
  * 짧은 시간 내 새로고침 시 조회수가 과도하게 증가하던 현상이 완화되었습니다.
  * 조회수 증가와 조회 이력 반영이 더 안정적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->