### PR TITLE
refactor: 블로그 목록/상세 데이터 소스를 Markdown으로 전환

### DIFF
--- a/src/app/(main)/blog/[slug]/page.tsx
+++ b/src/app/(main)/blog/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import { notFound } from "next/navigation";
 import PostDetail from "@/components/blog/PostDetail";
-import { posts } from "@/data/dummyData";
+import { getAllPosts, getPostBySlug } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
-  return posts.map((post) => ({ slug: post.slug }));
+  return getAllPosts().map((post) => ({ slug: post.slug }));
 }
 
 export async function generateMetadata({
@@ -14,7 +14,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const post = posts.find((p) => p.slug === slug);
+  const post = getPostBySlug(slug);
   if (!post) return buildMetadata();
   return buildMetadata({
     title: post.title,
@@ -33,7 +33,7 @@ export default async function PostPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const post = posts.find((p) => p.slug === slug);
+  const post = getPostBySlug(slug);
   if (!post) notFound();
 
   return <PostDetail post={post} />;

--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -1,4 +1,4 @@
-import { posts } from "@/data/dummyData";
+import { getAllPosts } from "@/lib/markdown/posts";
 import PostCard from "@/components/blog/PostCard";
 import { buildMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
@@ -9,6 +9,8 @@ export const metadata: Metadata = buildMetadata({
 });
 
 export default function Blog() {
+  const posts = getAllPosts();
+
   return (
     <section className="max-w-4xl mx-auto">
       <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-6 md:mb-8 text-[var(--color-accent)]">

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -116,7 +116,7 @@ export default function PostDetail({ post }: PostDetailProps) {
           <div
             className="post-content text-[var(--color-secondary)] leading-relaxed"
             dangerouslySetInnerHTML={{
-              __html: post.content.replace(/\n/g, "<br />"),
+              __html: post.content,
             }}
           />
 

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -28,6 +28,7 @@ type PostSource = {
 const postsDirectory = path.join(process.cwd(), "content/posts");
 const datePattern = /^\d{4}-\d{2}-\d{2}$/;
 let postSourceCache: PostSource[] | null = null;
+const htmlCache = new Map<string, string>();
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
@@ -85,6 +86,19 @@ function markdownToHtml(markdown: string): string {
   return String(remark().use(remarkGfm).use(remarkHtml).processSync(markdown));
 }
 
+function getPostHtml(source: PostSource): string {
+  const cached = htmlCache.get(source.fileName);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const html = markdownToHtml(source.content);
+  htmlCache.set(source.fileName, html);
+
+  return html;
+}
+
 function readPostSource(fileName: string): PostSource {
   const fullPath = path.join(postsDirectory, fileName);
   const fileContents = fs.readFileSync(fullPath, "utf8");
@@ -126,14 +140,14 @@ function getPublishedPostSources(): PostSource[] {
 }
 
 function buildPostFromSource(source: PostSource, id: number): Post {
-  const { content, frontmatter } = source;
+  const { frontmatter } = source;
 
   return {
     id,
     title: frontmatter.title,
     slug: frontmatter.slug,
     excerpt: frontmatter.excerpt,
-    content: markdownToHtml(content),
+    content: getPostHtml(source),
     category: frontmatter.category,
     categorySlug: frontmatter.categorySlug,
     tags: frontmatter.tags,


### PR DESCRIPTION
## 배경 및 목적

- 블로그 목록(`/blog`)과 상세(`/blog/[slug]`)가 `src/data/dummyData.ts`의 하드코딩된 `posts`에 의존하고 있음
- Markdown 전환 계획(`.claude/docs/markdown-blog-migration-plan.md`) 2단계로, 1단계에서 구축한 `content/posts` Markdown 파이프라인을 실제 페이지 데이터 소스로 연결함

## 설계

- 데이터 접근을 `src/lib/markdown/posts.ts`의 `getAllPosts()`, `getPostBySlug()`로 일원화하고 페이지 컴포넌트는 Markdown 파싱 방식을 알지 않도록 유지함
- `post.content`가 remark 파이프라인에서 이미 HTML로 변환되어 전달되므로, 기존 평문 전제의 `\n → <br />` 치환을 제거하고 변환된 HTML을 그대로 렌더링함

## 구현 내용

- `src/app/(main)/blog/page.tsx`
  - 목록 데이터를 `dummyData.posts`에서 `getAllPosts()`로 전환함
- `src/app/(main)/blog/[slug]/page.tsx`
  - `generateStaticParams`를 Markdown slug 기준으로 전환함
  - `generateMetadata`와 페이지 본문의 글 조회를 `getPostBySlug(slug)`로 전환함
- `src/components/blog/PostDetail.tsx`
  - 본문 렌더링에서 `\n → <br />` 치환을 제거하고 변환된 HTML을 그대로 사용함

## 코드 리뷰 포인트

- `dangerouslySetInnerHTML` 사용은 유지되나 입력 출처가 프로젝트 내부 `content/posts`로 제한됨 (외부 사용자 입력 없음)
- `getAllPosts()`는 `published: false` 글을 제외하므로 목록·정적 생성·메타데이터 모두 발행 글 기준으로 동작함

## 사이드이펙트 검토

- 카테고리/태그/RSS/sitemap/랜딩은 여전히 `dummyData` 기반이며 이번 범위가 아님 (계획 3~4단계에서 전환 예정)
- 댓글·조회수는 기존과 동일하게 `slug` 기준으로 동작하며 변경 없음
- Markdown 글과 더미데이터 글의 slug가 동일하므로 기존 URL이 유지됨

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `yarn build` 성공, `/blog/[slug]`가 Markdown slug 8건 기준으로 SSG 생성됨을 확인함
- `yarn start` 후 실제 요청으로 검증함
  - `/blog` 목록에 Markdown 글 노출 확인
  - `/blog/react-18-concurrent-rendering` 본문이 `<h2>` 등 변환된 HTML로 렌더링되고 `<br/>` 치환 잔재가 없음을 확인
  - 존재하지 않는 slug 요청 시 404 응답 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 블로그 목록과 상세 페이지가 더미 데이터가 아닌 실제 마크다운 콘텐츠를 기반으로 표시됩니다.
  * 제목·메타데이터·본문이 동일한 콘텐츠 소스에서 일관되게 제공됩니다.
* **버그 수정**
  * 존재하지 않는 게시글은 페이지 없음 화면으로 처리됩니다.
* **성능 개선**
  * 게시글 HTML 변환 결과를 캐시해 로딩 속도가 개선됩니다.
* **기타 변경**
  * 본문 줄바꿈 표시 방식이 변경되어 원문 형식에 맞게 렌더링됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->