### PR TITLE
refactor: 카테고리/태그 데이터 소스를 Markdown으로 전환

### DIFF
--- a/src/app/(main)/category/[slug]/page.tsx
+++ b/src/app/(main)/category/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import { notFound } from "next/navigation";
-import { categories, posts } from "@/data/dummyData";
+import { getAllCategories, getAllPosts } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import TaxonomyPostList from "@/components/blog/TaxonomyPostList";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
-  return categories.map((c) => ({ slug: c.slug }));
+  return getAllCategories().map((c) => ({ slug: c.slug }));
 }
 
 export async function generateMetadata({
@@ -14,7 +14,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const category = categories.find((c) => c.slug === slug);
+  const category = getAllCategories().find((c) => c.slug === slug);
   if (!category) return buildMetadata();
   return buildMetadata({
     title: category.name,
@@ -28,10 +28,10 @@ export default async function CategoryPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const category = categories.find((c) => c.slug === slug);
+  const category = getAllCategories().find((c) => c.slug === slug);
   if (!category) notFound();
 
-  const filteredPosts = posts.filter((p) => p.categorySlug === slug);
+  const filteredPosts = getAllPosts().filter((p) => p.categorySlug === slug);
 
   return <TaxonomyPostList title={category.name} posts={filteredPosts} />;
 }

--- a/src/app/(main)/category/page.tsx
+++ b/src/app/(main)/category/page.tsx
@@ -1,4 +1,4 @@
-import { categories } from "@/data/dummyData";
+import { getAllCategories } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import TaxonomyIndexGrid from "@/components/blog/TaxonomyIndexGrid";
 import type { Metadata } from "next";
@@ -9,6 +9,8 @@ export const metadata: Metadata = buildMetadata({
 });
 
 export default function CategoryIndex() {
+  const categories = getAllCategories();
+
   return (
     <TaxonomyIndexGrid
       title="Categories"

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,16 +1,20 @@
 import Sidebar from "@/components/common/Sidebar";
 import MobileBar from "@/components/common/MobileBar";
 import Footer from "@/components/common/footer";
+import { getAllCategories, getAllTags } from "@/lib/markdown/posts";
 
 export default function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const categories = getAllCategories();
+  const tags = getAllTags();
+
   return (
     <div className="flex min-h-screen bg-[var(--color-bg)]">
-      <Sidebar className="hidden md:flex" />
-      <MobileBar />
+      <Sidebar categories={categories} tags={tags} className="hidden md:flex" />
+      <MobileBar categories={categories} tags={tags} />
       <div className="flex-1 flex flex-col">
         <main className="flex-1 p-4 pt-20 md:p-10 md:pt-10">
           {children}

--- a/src/app/(main)/tag/[slug]/page.tsx
+++ b/src/app/(main)/tag/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import { notFound } from "next/navigation";
-import { tags, posts } from "@/data/dummyData";
+import { getAllTags, getAllPosts } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import TaxonomyPostList from "@/components/blog/TaxonomyPostList";
 import type { Metadata } from "next";
 
 export function generateStaticParams() {
-  return tags.map((t) => ({ slug: t.name.toLowerCase() }));
+  return getAllTags().map((t) => ({ slug: t.name.toLowerCase() }));
 }
 
 export async function generateMetadata({
@@ -14,7 +14,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const tag = tags.find((t) => t.name.toLowerCase() === slug.toLowerCase());
+  const tag = getAllTags().find((t) => t.name.toLowerCase() === slug.toLowerCase());
   if (!tag) return buildMetadata();
   return buildMetadata({
     title: `Tag: ${tag.name}`,
@@ -28,10 +28,10 @@ export default async function TagPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const tag = tags.find((t) => t.name.toLowerCase() === slug.toLowerCase());
+  const tag = getAllTags().find((t) => t.name.toLowerCase() === slug.toLowerCase());
   if (!tag) notFound();
 
-  const filteredPosts = posts.filter((p) =>
+  const filteredPosts = getAllPosts().filter((p) =>
     p.tags.map((t) => t.toLowerCase()).includes(slug.toLowerCase())
   );
 

--- a/src/app/(main)/tag/page.tsx
+++ b/src/app/(main)/tag/page.tsx
@@ -1,4 +1,4 @@
-import { tags } from "@/data/dummyData";
+import { getAllTags } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import TaxonomyIndexGrid from "@/components/blog/TaxonomyIndexGrid";
 import type { Metadata } from "next";
@@ -9,6 +9,8 @@ export const metadata: Metadata = buildMetadata({
 });
 
 export default function TagIndex() {
+  const tags = getAllTags();
+
   return (
     <TaxonomyIndexGrid
       title="Tags"

--- a/src/components/common/MobileBar.tsx
+++ b/src/components/common/MobileBar.tsx
@@ -6,8 +6,15 @@ import ThemeToggle from "@/components/common/ThemeToggle";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { Category, Tag } from "@/types";
 
-export default function MobileBar() {
+export default function MobileBar({
+  categories,
+  tags,
+}: {
+  categories: Category[];
+  tags: Tag[];
+}) {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
 
@@ -95,6 +102,8 @@ export default function MobileBar() {
         className={`md:hidden fixed top-12 right-0 z-40 w-64 h-[calc(100vh-3rem)] bg-[var(--color-bg)] border-l border-[var(--color-surface)] shadow-lg overflow-y-auto overflow-x-hidden transition-transform duration-300 ease-in-out ${open ? "translate-x-0" : "translate-x-full"}`}
       >
         <Sidebar
+          categories={categories}
+          tags={tags}
           className="flex border-r-0 !h-auto !w-full !p-4 text-sm"
           hideLogo
         />

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -3,11 +3,11 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { ComponentType } from "react";
-import { categories, tags, sitemap, blogInfo } from "@/data/dummyData";
+import { sitemap, blogInfo } from "@/data/dummyData";
 import ThemeToggle from "@/components/common/ThemeToggle";
 import { useTypewriter } from "@/hooks/useTypewriter";
 import { GitHubIcon, TwitterIcon, LinkedInIcon, EmailIcon } from "@/components/common/icons";
-import type { SocialIcon } from "@/types";
+import type { Category, SocialIcon, Tag } from "@/types";
 
 const SOCIAL_ICON_MAP: Record<SocialIcon, ComponentType<{ className?: string }>> = {
   github: GitHubIcon,
@@ -16,7 +16,17 @@ const SOCIAL_ICON_MAP: Record<SocialIcon, ComponentType<{ className?: string }>>
   email: EmailIcon,
 };
 
-export default function Sidebar({ className, hideLogo }: { className?: string; hideLogo?: boolean }) {
+export default function Sidebar({
+  categories,
+  tags,
+  className,
+  hideLogo,
+}: {
+  categories: Category[];
+  tags: Tag[];
+  className?: string;
+  hideLogo?: boolean;
+}) {
   const typedName = useTypewriter(blogInfo.author.name);
 
   return (


### PR DESCRIPTION
## 배경 및 목적

- Markdown 블로그 전환 3단계로 카테고리/태그 데이터 소스를 전환함
- 1단계에서 `getAllCategories()`, `getAllTags()`를 구현했으나 소비처는 여전히 `dummyData.ts`의 수동 목록을 사용하고 있었음
- 수동 목록은 글 추가·삭제 시 목록과 count를 직접 갱신해야 하는 한계가 있음
- 카테고리와 태그를 Markdown frontmatter에서 파생하고 count를 자동 계산하도록 전환함

## 설계

- `Sidebar`는 `useTypewriter` 훅 때문에 클라이언트 컴포넌트 유지가 필요함
- Markdown 모듈은 `node:fs`를 사용해 클라이언트 컴포넌트에서 직접 import 불가함
- 서버/클라이언트 컴포넌트 분리 대안 대신 서버인 `(main)/layout.tsx`에서 조회 후 props로 주입하는 최소 변경 방식을 선택함
- 태그 slug는 기존 `name.toLowerCase()` 규칙을 유지해 URL 변화를 없앰

## 구현 내용

- `category/page.tsx`: 카테고리 목록을 `getAllCategories()` 호출로 전환
- `category/[slug]/page.tsx`: `generateStaticParams`, `generateMetadata`, 글 필터링을 `getAllCategories()` + `getAllPosts()` 기준으로 전환
- `tag/page.tsx`: 태그 목록을 `getAllTags()` 호출로 전환
- `tag/[slug]/page.tsx`: `generateStaticParams`, `generateMetadata`, 글 필터링을 `getAllTags()` + `getAllPosts()` 기준으로 전환
- `Sidebar.tsx`: `categories`, `tags`를 props로 수신하도록 변경, `sitemap`·`blogInfo` import는 유지
- `MobileBar.tsx`: `categories`, `tags` props를 받아 내부 `Sidebar`에 전달
- `(main)/layout.tsx`: `getAllCategories()`, `getAllTags()` 조회 후 `Sidebar`와 `MobileBar`에 주입

## 코드 리뷰 포인트

- `Sidebar` props 시그니처 변경으로 사용처 2곳(`layout.tsx`, `MobileBar.tsx`)을 함께 수정함, 누락 사용처 여부 확인 필요
- `getAllCategories()`, `getAllTags()`는 `published: true` 글만 집계하므로 기존 더미데이터 목록과 노출 항목·count가 달라질 수 있음
- `Sidebar`의 Blog Stats 하드코딩 값(8/5/10/2.5K)은 이번 범위에서 제외함

## 사이드이펙트 검토

- 카테고리/태그 목록과 count가 Markdown 글 기준으로 변경됨, `content/posts`에 없는 카테고리·태그는 더 이상 노출되지 않음
- 카테고리/태그 URL 규칙은 기존과 동일함

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리 — 해당 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `tsc --noEmit` 타입 검사 통과함
- 변경 파일 7개 대상 ESLint 통과함
- 로컬 빌드와 실행 확인은 미수행함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 카테고리와 태그 페이지가 최신 마크다운 콘텐츠를 기반으로 목록과 게시물을 표시합니다.
  * 카테고리 및 태그 상세 페이지에서 존재하지 않는 항목을 올바르게 처리합니다.
  * 데스크톱 사이드바와 모바일 메뉴에 최신 카테고리·태그 목록이 표시됩니다.
  * 카테고리와 태그 목록 페이지의 콘텐츠가 동적으로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->