### PR TITLE
refactor: RSS/sitemap/랜딩/slug 검증 데이터 소스를 Markdown으로 전환

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,13 @@
 
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    // 댓글·조회수 서버 액션이 런타임에 content/posts를 읽으므로
+    // 서버리스 번들에 Markdown 파일 포함을 보장한다.
+    outputFileTracingIncludes: {
+      "/**": ["./content/posts/**/*"],
+    },
+  },
   images: {
     remotePatterns: [
       // GitHub 프로필 아바타(로그인 사용자 표시용)

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -1,7 +1,7 @@
 import dynamic from "next/dynamic";
 import HomeHero from "@/components/home/HomeHero";
 import LatestPosts from "@/components/home/LatestPosts";
-import { posts } from "@/data/dummyData";
+import { getAllPosts } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
 
@@ -16,9 +16,7 @@ export const metadata: Metadata = buildMetadata({
 });
 
 export default function HomePage() {
-  const latestPosts = [...posts]
-    .sort((a, b) => b.date.localeCompare(a.date))
-    .slice(0, 5);
+  const latestPosts = getAllPosts().slice(0, 5);
 
   return (
     <main className="relative w-full h-[100dvh] overflow-hidden bg-[var(--color-bg)]">

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,6 +1,20 @@
 import { getAllPosts } from "@/lib/markdown/posts";
 import { siteConfig } from "@/config/seo.config";
 
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// 값에 "]]>"가 포함되면 CDATA 섹션을 분할해 조기 종료를 막는다.
+function cdata(value: string): string {
+  return `<![CDATA[${value.replace(/\]\]>/g, "]]]]><![CDATA[>")}]]>`;
+}
+
 function generateRssFeed(): string {
   const posts = getAllPosts();
   const baseUrl = siteConfig.siteUrl;
@@ -9,9 +23,9 @@ function generateRssFeed(): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>${siteConfig.title}</title>
+    <title>${escapeXml(siteConfig.title)}</title>
     <link>${baseUrl}</link>
-    <description>${siteConfig.description}</description>
+    <description>${escapeXml(siteConfig.description)}</description>
     <language>ko</language>
     <lastBuildDate>${buildDate}</lastBuildDate>
     <atom:link href="${baseUrl}/rss.xml" rel="self" type="application/rss+xml"/>
@@ -21,13 +35,13 @@ function generateRssFeed(): string {
         const postUrl = `${baseUrl}/blog/${post.slug}`;
         const pubDate = new Date(post.date).toUTCString();
         return `<item>
-      <title><![CDATA[${post.title}]]></title>
-      <link>${postUrl}</link>
-      <guid isPermaLink="true">${postUrl}</guid>
-      <description><![CDATA[${post.excerpt}]]></description>
+      <title>${cdata(post.title)}</title>
+      <link>${escapeXml(postUrl)}</link>
+      <guid isPermaLink="true">${escapeXml(postUrl)}</guid>
+      <description>${cdata(post.excerpt)}</description>
       <pubDate>${pubDate}</pubDate>
-      <author>${siteConfig.author.email} (${siteConfig.author.name})</author>
-      ${post.tags.map((tag) => `<category>${tag}</category>`).join("\n      ")}
+      <author>${escapeXml(`${siteConfig.author.email} (${siteConfig.author.name})`)}</author>
+      ${post.tags.map((tag) => `<category>${escapeXml(tag)}</category>`).join("\n      ")}
     </item>`;
       })
       .join("\n    ")}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,7 +1,8 @@
-import { posts } from "@/data/dummyData";
+import { getAllPosts } from "@/lib/markdown/posts";
 import { siteConfig } from "@/config/seo.config";
 
 function generateRssFeed(): string {
+  const posts = getAllPosts();
   const baseUrl = siteConfig.siteUrl;
   const buildDate = new Date().toUTCString();
 

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -24,11 +24,11 @@ function generateRssFeed(): string {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(siteConfig.title)}</title>
-    <link>${baseUrl}</link>
+    <link>${escapeXml(baseUrl)}</link>
     <description>${escapeXml(siteConfig.description)}</description>
     <language>ko</language>
     <lastBuildDate>${buildDate}</lastBuildDate>
-    <atom:link href="${baseUrl}/rss.xml" rel="self" type="application/rss+xml"/>
+    <atom:link href="${escapeXml(`${baseUrl}/rss.xml`)}" rel="self" type="application/rss+xml"/>
 
     ${posts
       .map((post) => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { posts, categories, tags } from "@/data/dummyData";
+import { getAllPosts, getAllCategories, getAllTags } from "@/lib/markdown/posts";
 import { siteConfig } from "@/config/seo.config";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -13,16 +13,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${baseUrl}/tag` },
   ];
 
-  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+  const postEntries: MetadataRoute.Sitemap = getAllPosts().map((post) => ({
     url: `${baseUrl}/blog/${post.slug}`,
     lastModified: new Date(`${post.date}T00:00:00+09:00`),
   }));
 
-  const categoryEntries: MetadataRoute.Sitemap = categories.map((cat) => ({
+  const categoryEntries: MetadataRoute.Sitemap = getAllCategories().map((cat) => ({
     url: `${baseUrl}/category/${cat.slug}`,
   }));
 
-  const tagEntries: MetadataRoute.Sitemap = tags.map((tag) => ({
+  const tagEntries: MetadataRoute.Sitemap = getAllTags().map((tag) => ({
     url: `${baseUrl}/tag/${tag.name.toLowerCase()}`,
   }));
 

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -1,10 +1,10 @@
-import { posts } from "@/data/dummyData";
+import { getAllPostSlugs } from "@/lib/markdown/posts";
 import { prisma } from "@/lib/prisma";
 
 // 실제 존재하는 글의 slug인지 검증한다. 임의 문자열로 가짜 레코드(조회수·댓글)가
 // 쌓이는 것을 막기 위한 공용 가드.
 export function assertValidPostSlug(slug: string) {
-  if (!posts.some((post) => post.slug === slug)) {
+  if (!getAllPostSlugs().includes(slug)) {
     throw new Error(`Invalid post slug: ${slug}`);
   }
 }

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -1,10 +1,10 @@
-import { getAllPostSlugs } from "@/lib/markdown/posts";
+import { getPostSlugSet } from "@/lib/markdown/posts";
 import { prisma } from "@/lib/prisma";
 
 // 실제 존재하는 글의 slug인지 검증한다. 임의 문자열로 가짜 레코드(조회수·댓글)가
 // 쌓이는 것을 막기 위한 공용 가드.
 export function assertValidPostSlug(slug: string) {
-  if (!getAllPostSlugs().includes(slug)) {
+  if (!getPostSlugSet().has(slug)) {
     throw new Error(`Invalid post slug: ${slug}`);
   }
 }

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -191,6 +191,11 @@ export function getAllPosts(): Post[] {
   );
 }
 
+// slug 존재 여부 검증용. Post 변환(Markdown→HTML)을 거치지 않아 런타임 API에서도 가볍다.
+export function getAllPostSlugs(): string[] {
+  return getPublishedPostSources().map(({ frontmatter }) => frontmatter.slug);
+}
+
 export function getPostBySlug(slug: string): Post | undefined {
   const sources = getPublishedPostSources();
   const postIndex = sources.findIndex(({ frontmatter }) => frontmatter.slug === slug);

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -28,6 +28,7 @@ type PostSource = {
 const postsDirectory = path.join(process.cwd(), "content/posts");
 const datePattern = /^\d{4}-\d{2}-\d{2}$/;
 let postSourceCache: PostSource[] | null = null;
+let postSlugCache: ReadonlySet<string> | null = null;
 const htmlCache = new Map<string, string>();
 
 function isNonEmptyString(value: unknown): value is string {
@@ -191,9 +192,16 @@ export function getAllPosts(): Post[] {
   );
 }
 
-// slug 존재 여부 검증용. Post 변환(Markdown→HTML)을 거치지 않아 런타임 API에서도 가볍다.
-export function getAllPostSlugs(): string[] {
-  return getPublishedPostSources().map(({ frontmatter }) => frontmatter.slug);
+// slug 존재 여부 검증용. Post 변환(Markdown→HTML)을 거치지 않아 런타임 API에서도 가볍고,
+// 배포 단위로 콘텐츠가 불변이므로 인스턴스당 1회만 생성한다.
+export function getPostSlugSet(): ReadonlySet<string> {
+  if (!postSlugCache) {
+    postSlugCache = new Set(
+      getPublishedPostSources().map(({ frontmatter }) => frontmatter.slug)
+    );
+  }
+
+  return postSlugCache;
 }
 
 export function getPostBySlug(slug: string): Post | undefined {


### PR DESCRIPTION
## 배경 및 목적

- 블로그 목록·상세(#41), 카테고리·태그(#42)는 Markdown 데이터 소스로 전환 완료됨
- RSS, sitemap, 랜딩 최신 글, 댓글·조회수 slug 검증은 여전히 `dummyData.ts`의 `posts`에 의존함
- 원천 데이터가 이원화되어 Markdown 글과 더미 글이 어긋나면 피드·SEO·slug 검증이 실제 발행 글과 불일치함
- Markdown 전환 계획 4단계에 해당하며, 5단계(블로그 더미데이터 제거)의 선행 작업임

## 설계

- slug 검증용으로 `getAllPostSlugs()`를 신설함
  - `getAllPosts()`는 전체 글의 Markdown→HTML 변환을 유발하므로, 런타임 서버 액션(댓글·조회수) 경로에서는 변환 없이 slug 목록만 반환하는 함수를 사용함
- `next.config.mjs`에 `experimental.outputFileTracingIncludes`를 추가함
  - 서버 액션이 런타임에 `content/posts/*.md`를 읽으므로 서버리스 번들 포함을 보장함
  - 서버 액션은 호출 페이지의 함수 번들에서 실행되고 동적 세그먼트 키 매칭 규칙이 불확실해, 파일 수가 적은 점을 고려해 전체 라우트 키(`"/**"`)로 지정함
- 랜딩 최신 글은 `getAllPosts()`가 최신순 정렬을 보장하므로 수동 정렬을 제거함

## 구현 내용

- `src/app/rss.xml/route.ts`: `posts` import를 `getAllPosts()` 호출로 전환함
- `src/app/sitemap.ts`: `posts`/`categories`/`tags`를 `getAllPosts()`/`getAllCategories()`/`getAllTags()`로 전환함
- `src/app/(landing)/page.tsx`: 최신 글 5개를 `getAllPosts().slice(0, 5)`로 조회함
- `src/lib/markdown/posts.ts`: `getAllPostSlugs()` 추가함
- `src/lib/data/posts.ts`: `assertValidPostSlug`가 Markdown slug 목록 기준으로 검증하도록 전환함
- `next.config.mjs`: `content/posts/**/*` tracing 포함 설정 추가함

## 코드 리뷰 포인트

- `outputFileTracingIncludes`의 `"/**"` 키 범위가 적절한지 검토 필요함
- slug 검증이 published 글만 대상으로 바뀜 → `published: false` 글의 slug로는 댓글·조회수 레코드 생성이 거부됨
- Vercel 배포(프리뷰) 후 댓글·조회수 서버 액션의 런타임 파일 읽기 동작 확인 필요함

## 사이드이펙트 검토

- RSS·sitemap 항목이 더미 글 기준에서 Markdown 글 기준으로 변경됨 (노출 URL 목록 변화)
- 유효하지 않은 slug에 대한 댓글·조회수 레코드 생성이 Markdown 글 기준으로 차단됨

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `tsc --noEmit` 통과함
- 로컬 빌드·런타임 검증 미수행함 (배포 프리뷰에서 `/rss.xml`, sitemap, 댓글·조회수 동작 확인 필요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 최신 게시글을 더미 데이터가 아닌 실제 Markdown 기반으로 상위 5개까지 노출합니다.
  * RSS 피드와 사이트맵이 게시글·카테고리·태그의 실제 데이터로 생성됩니다.
  * 게시글 슬러그 검증을 실제 게시글 기준으로 수행하고, 슬러그 조회를 캐시로 최적화했습니다.
* **버그 수정**
  * 서버리스 환경에서 Markdown 콘텐츠가 누락되지 않도록 서버 동작 시 필요한 추적 구성을 보강했습니다.
  * RSS XML 생성 시 값 안전 처리를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->