### PR TITLE
feat: 실제 이전·다음 글 연결

### DIFF
--- a/src/app/(main)/blog/[slug]/page.tsx
+++ b/src/app/(main)/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import PostDetail from "@/components/blog/PostDetail";
-import { getAllPosts, getPostBySlug } from "@/lib/markdown/posts";
+import { getAdjacentPosts, getAllPosts, getPostBySlug } from "@/lib/markdown/posts";
 import { buildMetadata } from "@/lib/metadata";
 import type { Metadata } from "next";
 
@@ -35,6 +35,13 @@ export default async function PostPage({
   const { slug } = await params;
   const post = getPostBySlug(slug);
   if (!post) notFound();
+  const { previousPost, nextPost } = getAdjacentPosts(slug);
 
-  return <PostDetail post={post} />;
+  return (
+    <PostDetail
+      post={post}
+      previousPost={previousPost}
+      nextPost={nextPost}
+    />
+  );
 }

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -1,13 +1,19 @@
 import Link from "next/link";
 import CommentSection from "@/components/blog/comments/CommentSection";
 import ViewCounter from "@/components/blog/ViewCounter";
-import type { Post, TocItem } from "@/types";
+import type { Post, PostSummary, TocItem } from "@/types";
 
 interface PostDetailProps {
   post: Post;
+  previousPost?: PostSummary;
+  nextPost?: PostSummary;
 }
 
-export default function PostDetail({ post }: PostDetailProps) {
+export default function PostDetail({
+  post,
+  previousPost,
+  nextPost,
+}: PostDetailProps) {
 
   // 목차 생성 (간단한 버전)
   const tableOfContents: TocItem[] = [
@@ -222,54 +228,62 @@ export default function PostDetail({ post }: PostDetailProps) {
       {/* 이전/다음 포스트 네비게이션 */}
       <div className="mt-16 pt-8 border-t border-[var(--color-muted)]">
         <div className="grid grid-cols-2 gap-2 sm:gap-4">
-          <Link
-            href="/blog/prev"
-            className="flex items-center p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors group"
-          >
-            <svg
-              className="w-5 h-5 mr-2 sm:w-6 sm:h-6 sm:mr-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+          {previousPost ? (
+            <Link
+              href={`/blog/${previousPost.slug}`}
+              className="flex items-center p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors group"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            <div className="min-w-0">
-              <div className="text-xs text-[var(--color-secondary)] mb-1">이전 글</div>
-              <div className="text-sm sm:text-base font-semibold text-[var(--color-accent)] truncate">
-                이전 포스트 제목
+              <svg
+                className="w-5 h-5 mr-2 sm:w-6 sm:h-6 sm:mr-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 19l-7-7 7-7"
+                />
+              </svg>
+              <div className="min-w-0">
+                <div className="text-xs text-[var(--color-secondary)] mb-1">이전 글</div>
+                <div className="text-sm sm:text-base font-semibold text-[var(--color-accent)] truncate">
+                  {previousPost.title}
+                </div>
               </div>
-            </div>
-          </Link>
-          <Link
-            href="/blog/next"
-            className="flex items-center justify-end p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors group"
-          >
-            <div className="min-w-0 text-right">
-              <div className="text-xs text-[var(--color-secondary)] mb-1">다음 글</div>
-              <div className="text-sm sm:text-base font-semibold text-[var(--color-accent)] truncate">
-                다음 포스트 제목
-              </div>
-            </div>
-            <svg
-              className="w-5 h-5 ml-2 sm:w-6 sm:h-6 sm:ml-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+            </Link>
+          ) : (
+            <div />
+          )}
+          {nextPost ? (
+            <Link
+              href={`/blog/${nextPost.slug}`}
+              className="flex items-center justify-end p-3 sm:p-4 bg-[var(--color-surface)] border border-[var(--color-muted)] hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] transition-colors group"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 5l7 7-7 7"
-              />
-            </svg>
-          </Link>
+              <div className="min-w-0 text-right">
+                <div className="text-xs text-[var(--color-secondary)] mb-1">다음 글</div>
+                <div className="text-sm sm:text-base font-semibold text-[var(--color-accent)] truncate">
+                  {nextPost.title}
+                </div>
+              </div>
+              <svg
+                className="w-5 h-5 ml-2 sm:w-6 sm:h-6 sm:ml-3 flex-shrink-0 text-[var(--color-secondary)] group-hover:text-[var(--color-accent)]"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </Link>
+          ) : (
+            <div />
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -4,7 +4,7 @@ import matter from "gray-matter";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
-import type { Category, Post, Tag } from "@/types";
+import type { Category, Post, PostSummary, Tag } from "@/types";
 
 type PostFrontmatter = {
   title: string;
@@ -158,6 +158,13 @@ function buildPostFromSource(source: PostSource, id: number): Post {
   };
 }
 
+function buildPostSummary(source: PostSource): PostSummary {
+  return {
+    title: source.frontmatter.title,
+    slug: source.frontmatter.slug,
+  };
+}
+
 function ensureUniqueSlugs(slugs: string[]) {
   const seen = new Set<string>();
 
@@ -213,6 +220,27 @@ export function getPostBySlug(slug: string): Post | undefined {
   }
 
   return buildPostFromSource(sources[postIndex], postIndex + 1);
+}
+
+export function getAdjacentPosts(slug: string): {
+  previousPost?: PostSummary;
+  nextPost?: PostSummary;
+} {
+  const sources = getPublishedPostSources();
+  const postIndex = sources.findIndex(({ frontmatter }) => frontmatter.slug === slug);
+
+  if (postIndex === -1) {
+    return {};
+  }
+
+  return {
+    previousPost: sources[postIndex + 1]
+      ? buildPostSummary(sources[postIndex + 1])
+      : undefined,
+    nextPost: sources[postIndex - 1]
+      ? buildPostSummary(sources[postIndex - 1])
+      : undefined,
+  };
 }
 
 export function getAllCategories(): Category[] {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,11 @@ export interface Post {
   image: string;
 }
 
+export interface PostSummary {
+  title: string;
+  slug: string;
+}
+
 // ─── Category ────────────────────────────────────────────────────────────────
 
 export interface Category {


### PR DESCRIPTION
## 배경 및 목적

<!-- 왜 이 변경이 필요했는지. 문제·한계·요구사항을 구체적으로 -->

- 게시글 상세 하단의 /blog/prev와 /blog/next 더미 링크 제거
- 현재 게시글과 인접한 실제 게시글로 이동할 수 있는 탐색 경로 제공

## 설계

<!-- 핵심 구조 결정 이유. 대안이 있었다면 왜 이 방향을 선택했는지 -->

- 공개 게시글의 게시일 내림차순 정렬 결과에서 현재 slug의 인접 항목 계산
- 상세 화면에는 제목과 slug만 포함하는 PostSummary 전달
- 인접 글이 없는 방향은 빈 그리드 셀로 유지해 내비게이션 정렬 보존

## 구현 내용

<!-- 기능 소개 및 파일별 변경 요약 -->

- Markdown 게시글 데이터 계층에 getAdjacentPosts 추가
- 게시글 상세 페이지에서 이전·다음 글 요약 조회 및 전달
- PostDetail의 더미 주소와 제목을 실제 slug와 제목으로 교체
- 첫 글과 마지막 글에서 존재하는 방향의 링크만 렌더링

## 코드 리뷰 포인트

<!-- 리뷰어가 특히 봐야 할 부분, 트레이드오프, 주의사항 -->

- 이전 글을 더 오래된 게시글, 다음 글을 더 최신 게시글로 정의한 정렬 방향 검토 필요
- 양 끝 게시글에서 빈 셀이 의도한 좌우 정렬을 유지하는지 검토 필요

## 사이드이펙트 검토

<!-- 이 변경이 기존 동작·사용자·연관 기능에 미치는 영향. 없으면 "없음"으로 명시 -->

- 목차와 읽기 진행률 동작 변경 없음

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

<!-- 복잡한 변경일 때만 작성. 단순 수정은 생략 가능 -->

- git diff --check 통과
- 더미 주소와 제목 문자열 제거 확인
- 읽기 진행률 코드 미포함 확인
- 프로젝트 운영 정책에 따라 빌드·개발 서버·브라우저 자동 테스트 미실행
- 최신·중간·최오래된 게시글 내비게이션은 수동 UI 테스트 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 블로그 게시물 하단에 실제 이전 글/다음 글로 이동할 수 있는 내비게이션을 추가했습니다.
  * 이전 글과 다음 글이 각각 존재할 때만 링크가 표시됩니다.
  * 링크에는 해당 글의 제목이 표시되며, 클릭 시 선택한 글의 상세 페이지로 이동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->