### PR TITLE
feat: Markdown 기반 게시글 목차 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@prisma/client": "6",
     "framer-motion": "^11.5.4",
     "gray-matter": "^4.0.3",
+    "hast-util-sanitize": "^5.0.0",
     "next": "14.2.8",
     "next-auth": "^5.0.0-beta.31",
     "pixi.js": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
     "sharp": "^0.33.5",
+    "unist-util-visit": "^5.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/mdast": "^4.0.0",
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -1,23 +1,14 @@
 import Link from "next/link";
 import CommentSection from "@/components/blog/comments/CommentSection";
+import PostTocVisibility from "@/components/blog/PostTocVisibility";
 import ViewCounter from "@/components/blog/ViewCounter";
-import type { Post, TocItem } from "@/types";
+import type { Post } from "@/types";
 
 interface PostDetailProps {
   post: Post;
 }
 
 export default function PostDetail({ post }: PostDetailProps) {
-
-  // 목차 생성 (간단한 버전)
-  const tableOfContents: TocItem[] = [
-    { id: "intro", title: "소개", level: 1 },
-    { id: "section1", title: "주요 개념", level: 1 },
-    { id: "section2", title: "실전 예제", level: 1 },
-    { id: "section3", title: "베스트 프랙티스", level: 1 },
-    { id: "conclusion", title: "마무리", level: 1 },
-  ];
-
   return (
     <div className="max-w-5xl mx-auto">
       {/* 헤더 */}
@@ -162,58 +153,59 @@ export default function PostDetail({ post }: PostDetailProps) {
           </div>
         </article>
 
-        {/* 목차 (우측 고정) */}
-        <aside className="hidden lg:block w-64 flex-shrink-0">
-          <div className="sticky top-24">
-            <div className="bg-[var(--color-bg)] border border-[var(--color-surface)] p-5">
-              <h3 className="text-lg font-bold text-[var(--color-accent)] mb-4 flex items-center">
-                <svg
-                  className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h7"
-                  />
-                </svg>
-                목차
-              </h3>
-              <nav>
-                <ul className="space-y-2">
-                  {tableOfContents.map((item) => (
-                    <li key={item.id}>
-                      <a
-                        href={`#${item.id}`}
-                        className="block text-sm py-1 px-2 transition-colors text-[var(--color-secondary)] hover:text-[var(--color-accent)] hover:bg-[var(--color-surface)] border-l-2 border-transparent"
-                        style={{ paddingLeft: `${item.level * 0.75}rem` }}
-                      >
-                        {item.title}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </nav>
+        {post.toc.length > 0 && (
+          <PostTocVisibility bodyTocId="목차" postSlug={post.slug}>
+            <div className="sticky top-24">
+              <div className="bg-[var(--color-bg)] border border-[var(--color-surface)] p-5">
+                <h3 className="text-lg font-bold text-[var(--color-accent)] mb-4 flex items-center">
+                  <svg
+                    className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 6h16M4 12h16M4 18h7"
+                    />
+                  </svg>
+                  목차
+                </h3>
+                <nav>
+                  <ul className="space-y-2">
+                    {post.toc.map((item) => (
+                      <li key={item.id}>
+                        <a
+                          href={`#${item.id}`}
+                          className="block text-sm py-1 px-2 transition-colors text-[var(--color-secondary)] hover:text-[var(--color-accent)] hover:bg-[var(--color-surface)] border-l-2 border-transparent"
+                          style={{ paddingLeft: `${(item.level - 1) * 0.75}rem` }}
+                        >
+                          {item.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
 
-              {/* 스크롤 진행률 */}
-              <div className="mt-6 pt-4 border-t border-[var(--color-muted)]">
-                <div className="flex justify-between text-xs text-[var(--color-secondary)] mb-2">
-                  <span>읽기 진행률</span>
-                  <span>45%</span>
-                </div>
-                <div className="w-full bg-[var(--color-surface)] border border-[var(--color-muted)] h-2">
-                  <div
-                    className="bg-[var(--color-accent)] h-2"
-                    style={{ width: "45%" }}
-                  ></div>
+                {/* 스크롤 진행률 */}
+                <div className="mt-6 pt-4 border-t border-[var(--color-muted)]">
+                  <div className="flex justify-between text-xs text-[var(--color-secondary)] mb-2">
+                    <span>읽기 진행률</span>
+                    <span>45%</span>
+                  </div>
+                  <div className="w-full bg-[var(--color-surface)] border border-[var(--color-muted)] h-2">
+                    <div
+                      className="bg-[var(--color-accent)] h-2"
+                      style={{ width: "45%" }}
+                    ></div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </aside>
+          </PostTocVisibility>
+        )}
       </div>
 
       {/* 댓글 영역 */}

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -156,7 +156,10 @@ export default function PostDetail({ post }: PostDetailProps) {
         <aside className="hidden lg:block w-64 flex-shrink-0">
           <div className="sticky top-24">
             {post.toc.length > 0 && (
-              <PostTocVisibility bodyTocId="목차" postSlug={post.slug}>
+              <PostTocVisibility
+                bodyTocId={post.inlineTocId}
+                postSlug={post.slug}
+              >
                 <div className="bg-[var(--color-bg)] border border-[var(--color-surface)] p-5">
                   <h3 className="text-lg font-bold text-[var(--color-accent)] mb-4 flex items-center">
                     <svg

--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -153,59 +153,65 @@ export default function PostDetail({ post }: PostDetailProps) {
           </div>
         </article>
 
-        {post.toc.length > 0 && (
-          <PostTocVisibility bodyTocId="목차" postSlug={post.slug}>
-            <div className="sticky top-24">
-              <div className="bg-[var(--color-bg)] border border-[var(--color-surface)] p-5">
-                <h3 className="text-lg font-bold text-[var(--color-accent)] mb-4 flex items-center">
-                  <svg
-                    className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 6h16M4 12h16M4 18h7"
-                    />
-                  </svg>
-                  목차
-                </h3>
-                <nav>
-                  <ul className="space-y-2">
-                    {post.toc.map((item) => (
-                      <li key={item.id}>
-                        <a
-                          href={`#${item.id}`}
-                          className="block text-sm py-1 px-2 transition-colors text-[var(--color-secondary)] hover:text-[var(--color-accent)] hover:bg-[var(--color-surface)] border-l-2 border-transparent"
-                          style={{ paddingLeft: `${(item.level - 1) * 0.75}rem` }}
-                        >
-                          {item.title}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </nav>
-
-                {/* 스크롤 진행률 */}
-                <div className="mt-6 pt-4 border-t border-[var(--color-muted)]">
-                  <div className="flex justify-between text-xs text-[var(--color-secondary)] mb-2">
-                    <span>읽기 진행률</span>
-                    <span>45%</span>
-                  </div>
-                  <div className="w-full bg-[var(--color-surface)] border border-[var(--color-muted)] h-2">
-                    <div
-                      className="bg-[var(--color-accent)] h-2"
-                      style={{ width: "45%" }}
-                    ></div>
-                  </div>
+        <aside className="hidden lg:block w-64 flex-shrink-0">
+          <div className="sticky top-24">
+            {post.toc.length > 0 && (
+              <PostTocVisibility bodyTocId="목차" postSlug={post.slug}>
+                <div className="bg-[var(--color-bg)] border border-[var(--color-surface)] p-5">
+                  <h3 className="text-lg font-bold text-[var(--color-accent)] mb-4 flex items-center">
+                    <svg
+                      className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M4 6h16M4 12h16M4 18h7"
+                      />
+                    </svg>
+                    목차
+                  </h3>
+                  <nav>
+                    <ul className="space-y-2">
+                      {post.toc.map((item) => (
+                        <li key={item.id}>
+                          <a
+                            href={`#${item.id}`}
+                            className="block text-sm py-1 px-2 transition-colors text-[var(--color-secondary)] hover:text-[var(--color-accent)] hover:bg-[var(--color-surface)] border-l-2 border-transparent"
+                            style={{ paddingLeft: `${(item.level - 1) * 0.75}rem` }}
+                          >
+                            {item.title}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </nav>
                 </div>
+              </PostTocVisibility>
+            )}
+
+            {/* 스크롤 진행률 */}
+            <div
+              className={`bg-[var(--color-bg)] border border-[var(--color-surface)] p-5 ${
+                post.toc.length > 0 ? "mt-4" : ""
+              }`}
+            >
+              <div className="flex justify-between text-xs text-[var(--color-secondary)] mb-2">
+                <span>읽기 진행률</span>
+                <span>45%</span>
+              </div>
+              <div className="w-full bg-[var(--color-surface)] border border-[var(--color-muted)] h-2">
+                <div
+                  className="bg-[var(--color-accent)] h-2"
+                  style={{ width: "45%" }}
+                ></div>
               </div>
             </div>
-          </PostTocVisibility>
-        )}
+          </div>
+        </aside>
       </div>
 
       {/* 댓글 영역 */}

--- a/src/components/blog/PostTocVisibility.tsx
+++ b/src/components/blog/PostTocVisibility.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 
 interface PostTocVisibilityProps {
-  bodyTocId: string;
+  bodyTocId?: string;
   postSlug: string;
   children: ReactNode;
 }
@@ -13,9 +13,17 @@ export default function PostTocVisibility({
   postSlug,
   children,
 }: PostTocVisibilityProps) {
-  const [isBodyTocVisible, setIsBodyTocVisible] = useState(true);
+  const [isBodyTocVisible, setIsBodyTocVisible] = useState(
+    bodyTocId !== undefined
+  );
 
   useEffect(() => {
+    if (!bodyTocId) {
+      setIsBodyTocVisible(false);
+      return;
+    }
+
+    setIsBodyTocVisible(true);
     const bodyTocHeading = document.getElementById(bodyTocId);
 
     if (!bodyTocHeading) {

--- a/src/components/blog/PostTocVisibility.tsx
+++ b/src/components/blog/PostTocVisibility.tsx
@@ -49,14 +49,14 @@ export default function PostTocVisibility({
   }, [bodyTocId, postSlug]);
 
   return (
-    <aside
-      className={`hidden lg:block w-64 flex-shrink-0 transition-opacity duration-300 motion-reduce:transition-none ${
+    <div
+      className={`transition-opacity duration-300 motion-reduce:transition-none ${
         isBodyTocVisible ? "opacity-0 pointer-events-none" : "opacity-100"
       }`}
       aria-hidden={isBodyTocVisible}
       inert={isBodyTocVisible || undefined}
     >
       {children}
-    </aside>
+    </div>
   );
 }

--- a/src/components/blog/PostTocVisibility.tsx
+++ b/src/components/blog/PostTocVisibility.tsx
@@ -13,17 +13,15 @@ export default function PostTocVisibility({
   postSlug,
   children,
 }: PostTocVisibilityProps) {
-  const [isBodyTocVisible, setIsBodyTocVisible] = useState(
-    bodyTocId !== undefined
-  );
+  const [isBodyTocVisible, setIsBodyTocVisible] = useState(false);
 
   useEffect(() => {
+    setIsBodyTocVisible(false);
+
     if (!bodyTocId) {
-      setIsBodyTocVisible(false);
       return;
     }
 
-    setIsBodyTocVisible(true);
     const bodyTocHeading = document.getElementById(bodyTocId);
 
     if (!bodyTocHeading) {

--- a/src/components/blog/PostTocVisibility.tsx
+++ b/src/components/blog/PostTocVisibility.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+
+interface PostTocVisibilityProps {
+  bodyTocId: string;
+  postSlug: string;
+  children: ReactNode;
+}
+
+export default function PostTocVisibility({
+  bodyTocId,
+  postSlug,
+  children,
+}: PostTocVisibilityProps) {
+  const [isBodyTocVisible, setIsBodyTocVisible] = useState(true);
+
+  useEffect(() => {
+    const bodyTocHeading = document.getElementById(bodyTocId);
+
+    if (!bodyTocHeading) {
+      setIsBodyTocVisible(false);
+      return;
+    }
+
+    const targets = [bodyTocHeading];
+    const bodyTocList = bodyTocHeading.nextElementSibling;
+
+    if (bodyTocList?.matches("ul, ol")) {
+      targets.push(bodyTocList as HTMLElement);
+    }
+
+    const visibilityByTarget = new Map<Element, boolean>(
+      targets.map((target) => [target, false])
+    );
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        visibilityByTarget.set(entry.target, entry.isIntersecting);
+      }
+
+      setIsBodyTocVisible(
+        Array.from(visibilityByTarget.values()).some(Boolean)
+      );
+    });
+
+    targets.forEach((target) => observer.observe(target));
+
+    return () => observer.disconnect();
+  }, [bodyTocId, postSlug]);
+
+  return (
+    <aside
+      className={`hidden lg:block w-64 flex-shrink-0 transition-opacity duration-300 motion-reduce:transition-none ${
+        isBodyTocVisible ? "opacity-0 pointer-events-none" : "opacity-100"
+      }`}
+      aria-hidden={isBodyTocVisible}
+      inert={isBodyTocVisible || undefined}
+    >
+      {children}
+    </aside>
+  );
+}

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -39,6 +39,7 @@ type MarkdownNode = {
 type RenderedPost = {
   html: string;
   toc: TocItem[];
+  inlineTocId?: string;
 };
 
 const postsDirectory = path.join(process.cwd(), "content/posts");
@@ -141,6 +142,7 @@ function getRenderedPost(source: PostSource): RenderedPost {
 
   const toc: TocItem[] = [];
   const usedIds = new Map<string, number>();
+  let inlineTocId: string | undefined;
 
   function visit(node: MarkdownNode) {
     if (
@@ -160,7 +162,9 @@ function getRenderedPost(source: PostSource): RenderedPost {
         },
       };
 
-      if (title !== "목차") {
+      if (title === "목차") {
+        inlineTocId = id;
+      } else {
         toc.push({ id, title, level: node.depth });
       }
     }
@@ -175,7 +179,7 @@ function getRenderedPost(source: PostSource): RenderedPost {
       .use(remarkHtml, { sanitize: markdownSanitizeSchema })
       .processSync(source.content)
   );
-  const renderedPost = { html, toc };
+  const renderedPost = { html, toc, inlineTocId };
   renderedPostCache.set(source.fileName, renderedPost);
 
   return renderedPost;
@@ -232,6 +236,7 @@ function buildPostFromSource(source: PostSource, id: number): Post {
     excerpt: frontmatter.excerpt,
     content: renderedPost.html,
     toc: renderedPost.toc,
+    inlineTocId: renderedPost.inlineTocId,
     category: frontmatter.category,
     categorySlug: frontmatter.categorySlug,
     tags: frontmatter.tags,

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -5,6 +5,8 @@ import { defaultSchema } from "hast-util-sanitize";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
+import { visit } from "unist-util-visit";
+import type { Heading, PhrasingContent, Root } from "mdast";
 import type { Category, Post, Tag, TocItem } from "@/types";
 
 type PostFrontmatter = {
@@ -24,16 +26,6 @@ type PostSource = {
   fileName: string;
   frontmatter: PostFrontmatter;
   content: string;
-};
-
-type MarkdownNode = {
-  type: string;
-  depth?: number;
-  value?: string;
-  children?: MarkdownNode[];
-  data?: {
-    hProperties?: Record<string, unknown>;
-  };
 };
 
 type RenderedPost = {
@@ -128,12 +120,20 @@ function getUniqueHeadingId(baseId: string, usedIds: Set<string>): string {
   return id;
 }
 
-function getMarkdownText(node: MarkdownNode): string {
-  if (typeof node.value === "string") {
+function getMarkdownText(node: PhrasingContent): string {
+  if ("value" in node && typeof node.value === "string") {
     return node.value;
   }
 
-  return node.children?.map(getMarkdownText).join("") ?? "";
+  if ("alt" in node && typeof node.alt === "string") {
+    return node.alt;
+  }
+
+  if ("children" in node) {
+    return node.children.map(getMarkdownText).join("");
+  }
+
+  return "";
 }
 
 function getRenderedPost(source: PostSource): RenderedPost {
@@ -147,14 +147,13 @@ function getRenderedPost(source: PostSource): RenderedPost {
   const usedIds = new Set<string>();
   let inlineTocId: string | undefined;
 
-  function visit(node: MarkdownNode) {
-    if (
-      node.type === "heading" &&
-      node.depth !== undefined &&
-      node.depth >= 2 &&
-      node.depth <= 4
-    ) {
-      const title = getMarkdownText(node).trim();
+  const collectHeadings = () => (tree: Root) => {
+    visit(tree, "heading", (node: Heading) => {
+      if (node.depth < 2 || node.depth > 4) {
+        return;
+      }
+
+      const title = node.children.map(getMarkdownText).join("").trim();
       const id = getUniqueHeadingId(slugifyHeading(title), usedIds);
 
       node.data = {
@@ -170,15 +169,13 @@ function getRenderedPost(source: PostSource): RenderedPost {
       } else {
         toc.push({ id, title, level: node.depth });
       }
-    }
-
-    node.children?.forEach(visit);
-  }
+    });
+  };
 
   const html = String(
     remark()
       .use(remarkGfm)
-      .use(() => (tree) => visit(tree as MarkdownNode))
+      .use(collectHeadings)
       .use(remarkHtml, { sanitize: markdownSanitizeSchema })
       .processSync(source.content)
   );

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
+import { defaultSchema } from "hast-util-sanitize";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
-import type { Category, Post, Tag } from "@/types";
+import type { Category, Post, Tag, TocItem } from "@/types";
 
 type PostFrontmatter = {
   title: string;
@@ -25,11 +26,30 @@ type PostSource = {
   content: string;
 };
 
+type MarkdownNode = {
+  type: string;
+  depth?: number;
+  value?: string;
+  children?: MarkdownNode[];
+  data?: {
+    hProperties?: Record<string, unknown>;
+  };
+};
+
+type RenderedPost = {
+  html: string;
+  toc: TocItem[];
+};
+
 const postsDirectory = path.join(process.cwd(), "content/posts");
 const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+const markdownSanitizeSchema = {
+  ...defaultSchema,
+  clobberPrefix: "",
+};
 let postSourceCache: PostSource[] | null = null;
 let postSlugCache: ReadonlySet<string> | null = null;
-const htmlCache = new Map<string, string>();
+const renderedPostCache = new Map<string, RenderedPost>();
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
@@ -83,21 +103,82 @@ function parseFrontmatter(data: Record<string, unknown>, fileName: string): Post
   };
 }
 
-function markdownToHtml(markdown: string): string {
-  return String(remark().use(remarkGfm).use(remarkHtml).processSync(markdown));
+function slugifyHeading(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, "")
+    .replace(/\s+/g, "-");
 }
 
-function getPostHtml(source: PostSource): string {
-  const cached = htmlCache.get(source.fileName);
+function getUniqueHeadingId(baseId: string, usedIds: Map<string, number>): string {
+  const fallbackId = baseId || "section";
+  const count = usedIds.get(fallbackId) ?? 0;
+  usedIds.set(fallbackId, count + 1);
+
+  if (count === 0) {
+    return fallbackId;
+  }
+
+  return `${fallbackId}-${count + 1}`;
+}
+
+function getMarkdownText(node: MarkdownNode): string {
+  if (typeof node.value === "string") {
+    return node.value;
+  }
+
+  return node.children?.map(getMarkdownText).join("") ?? "";
+}
+
+function getRenderedPost(source: PostSource): RenderedPost {
+  const cached = renderedPostCache.get(source.fileName);
 
   if (cached !== undefined) {
     return cached;
   }
 
-  const html = markdownToHtml(source.content);
-  htmlCache.set(source.fileName, html);
+  const toc: TocItem[] = [];
+  const usedIds = new Map<string, number>();
 
-  return html;
+  function visit(node: MarkdownNode) {
+    if (
+      node.type === "heading" &&
+      node.depth !== undefined &&
+      node.depth >= 2 &&
+      node.depth <= 4
+    ) {
+      const title = getMarkdownText(node).trim();
+      const id = getUniqueHeadingId(slugifyHeading(title), usedIds);
+
+      node.data = {
+        ...node.data,
+        hProperties: {
+          ...node.data?.hProperties,
+          id,
+        },
+      };
+
+      if (title !== "목차") {
+        toc.push({ id, title, level: node.depth });
+      }
+    }
+
+    node.children?.forEach(visit);
+  }
+
+  const html = String(
+    remark()
+      .use(remarkGfm)
+      .use(() => (tree) => visit(tree as MarkdownNode))
+      .use(remarkHtml, { sanitize: markdownSanitizeSchema })
+      .processSync(source.content)
+  );
+  const renderedPost = { html, toc };
+  renderedPostCache.set(source.fileName, renderedPost);
+
+  return renderedPost;
 }
 
 function readPostSource(fileName: string): PostSource {
@@ -142,13 +223,15 @@ function getPublishedPostSources(): PostSource[] {
 
 function buildPostFromSource(source: PostSource, id: number): Post {
   const { frontmatter } = source;
+  const renderedPost = getRenderedPost(source);
 
   return {
     id,
     title: frontmatter.title,
     slug: frontmatter.slug,
     excerpt: frontmatter.excerpt,
-    content: getPostHtml(source),
+    content: renderedPost.html,
+    toc: renderedPost.toc,
     category: frontmatter.category,
     categorySlug: frontmatter.categorySlug,
     tags: frontmatter.tags,

--- a/src/lib/markdown/posts.ts
+++ b/src/lib/markdown/posts.ts
@@ -113,16 +113,19 @@ function slugifyHeading(value: string): string {
     .replace(/\s+/g, "-");
 }
 
-function getUniqueHeadingId(baseId: string, usedIds: Map<string, number>): string {
+function getUniqueHeadingId(baseId: string, usedIds: Set<string>): string {
   const fallbackId = baseId || "section";
-  const count = usedIds.get(fallbackId) ?? 0;
-  usedIds.set(fallbackId, count + 1);
+  let id = fallbackId;
+  let suffix = 1;
 
-  if (count === 0) {
-    return fallbackId;
+  while (usedIds.has(id)) {
+    suffix += 1;
+    id = `${fallbackId}-${suffix}`;
   }
 
-  return `${fallbackId}-${count + 1}`;
+  usedIds.add(id);
+
+  return id;
 }
 
 function getMarkdownText(node: MarkdownNode): string {
@@ -141,7 +144,7 @@ function getRenderedPost(source: PostSource): RenderedPost {
   }
 
   const toc: TocItem[] = [];
-  const usedIds = new Map<string, number>();
+  const usedIds = new Set<string>();
   let inlineTocId: string | undefined;
 
   function visit(node: MarkdownNode) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Post {
   excerpt: string;
   content: string;
   toc: TocItem[];
+  inlineTocId?: string;
   category: string;
   categorySlug: string;
   tags: string[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Post {
   slug: string;
   excerpt: string;
   content: string;
+  toc: TocItem[];
   category: string;
   categorySlug: string;
   tags: string[];


### PR DESCRIPTION
## 배경 및 목적

<!-- 왜 이 변경이 필요했는지. 문제·한계·요구사항을 구체적으로 -->

- 게시글 내용과 무관한 고정 우측 목차 더미 데이터 제거
- 실제 Markdown heading을 기준으로 본문 탐색 링크 제공
- 본문 목차와 우측 목차가 동시에 보이는 중복 상태 완화

## 설계

<!-- 핵심 구조 결정 이유. 대안이 있었다면 왜 이 방향을 선택했는지 -->

- remark AST 순회 한 번에서 heading ID와 목차 데이터 동시 생성
- 변환 HTML과 목차를 하나의 게시글 렌더링 캐시로 관리
- 내부 Markdown 입력 전제에서 HTML 정제는 유지하고 clobber 접두사만 비활성화
- 본문 목차 제목과 바로 다음 목록을 IntersectionObserver로 관찰
- 우측 목차 공간을 유지한 채 opacity transition으로 표시 상태 전환

## 구현 내용

<!-- 기능 소개 및 파일별 변경 요약 -->

- h2~h4 heading에서 중복 방지 bare ID와 목차 항목 생성
- 본문의 목차 heading은 우측 목차 항목에서 제외
- Post 모델에 실제 목차 데이터 추가
- PostDetail의 고정 목차 배열을 실제 게시글 목차로 교체
- 본문 목차가 보일 때 우측 목차를 숨기고 벗어나면 표시
- 숨김 상태에서 우측 목차의 포인터와 키보드 접근 차단
- 게시글 전환 시 목차 관찰 대상 재연결

## 코드 리뷰 포인트

<!-- 리뷰어가 특히 봐야 할 부분, 트레이드오프, 주의사항 -->

- sanitize schema의 clobberPrefix 비활성화가 내부 Markdown 전제에 적합한지 검토 필요
- heading slug 중복 처리와 한글·영문 혼합 제목 ID 생성 규칙 검토 필요
- 본문 목차 제목과 목록의 교차 상태를 함께 추적하는 로직 검토 필요

## 사이드이펙트 검토

<!-- 이 변경이 기존 동작·사용자·연관 기능에 미치는 영향. 없으면 "없음"으로 명시 -->

- 기존 고정 45% 진행률은 별도 PR 범위이므로 유지
- 기존 /blog/prev와 /blog/next 링크는 별도 PR 범위이므로 유지
- 우측 목차는 lg 이상 화면에서만 표시

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [x] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

<!-- 복잡한 변경일 때만 작성. 단순 수정은 생략 가능 -->

- git diff --check 통과
- user-content- 접두사와 고정 목차 배열 제거 확인
- 읽기 진행률과 이전·다음 글 변경 미포함 확인
- 프로젝트 운영 정책에 따라 빌드·개발 서버·브라우저 자동 테스트 미실행
- 목차 링크 이동과 opacity 전환은 수동 UI 테스트 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글에서 자동 생성된 목차를 렌더링하고, 본문 내 “목차” 섹션 위치에 맞춰 구성됩니다.
* **개선 사항**
  * 우측 목차는 스크롤 위치에 따라 자동으로 표시/숨김 처리되어 접근성(상태 전환)과 상호작용이 개선되었습니다.
  * 목차 항목 들여쓰기 및 목차 영역 내 진행 표시 레이아웃이 재정렬되었습니다.
  * 마크다운 HTML 정제 처리 방식이 강화되어 안전한 렌더링이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->