### PR TITLE
feat: 공유하기 URL 복사 구현 및 대표 이메일 통일

### DIFF
--- a/src/components/blog/PostDetail.tsx
+++ b/src/components/blog/PostDetail.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import CommentSection from "@/components/blog/comments/CommentSection";
 import PostTocVisibility from "@/components/blog/PostTocVisibility";
 import ReadingProgress from "@/components/blog/ReadingProgress";
+import ShareButton from "@/components/blog/ShareButton";
 import ViewCounter from "@/components/blog/ViewCounter";
 import type { Post, PostSummary } from "@/types";
 
@@ -127,38 +128,7 @@ export default function PostDetail({
               이 글이 도움이 되셨나요?
             </h3>
             <div className="flex gap-4">
-              <button className="flex items-center px-4 py-2 bg-[var(--color-surface)] border border-[var(--color-accent)] text-[var(--color-accent)] hover:bg-[var(--color-muted)] transition-colors">
-                <svg
-                  className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"
-                  />
-                </svg>
-                좋아요
-              </button>
-              <button className="flex items-center px-4 py-2 bg-[var(--color-surface)] border border-[var(--color-muted)] text-[var(--color-secondary)] hover:bg-[var(--color-muted)] transition-colors">
-                <svg
-                  className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-                  />
-                </svg>
-                공유하기
-              </button>
+              <ShareButton />
             </div>
           </div>
         </article>

--- a/src/components/blog/ShareButton.tsx
+++ b/src/components/blog/ShareButton.tsx
@@ -1,15 +1,42 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function ShareButton() {
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+
+      if (copiedTimerRef.current !== null) {
+        clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (copiedTimerRef.current !== null) {
+        clearTimeout(copiedTimerRef.current);
+      }
+
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      copiedTimerRef.current = setTimeout(() => {
+        setCopied(false);
+        copiedTimerRef.current = null;
+      }, 2000);
     } catch {
       // 클립보드 접근이 차단된 환경에서는 무시
     }

--- a/src/components/blog/ShareButton.tsx
+++ b/src/components/blog/ShareButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ShareButton() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // 클립보드 접근이 차단된 환경에서는 무시
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="flex items-center px-4 py-2 bg-[var(--color-surface)] border border-[var(--color-muted)] text-[var(--color-secondary)] hover:bg-[var(--color-muted)] transition-colors"
+    >
+      {copied ? (
+        <>
+          <svg
+            className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+          링크 복사됨
+        </>
+      ) : (
+        <>
+          <svg
+            className="w-4 h-4 mr-1.5 md:w-5 md:h-5 md:mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+            />
+          </svg>
+          공유하기
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/config/seo.config.ts
+++ b/src/config/seo.config.ts
@@ -8,7 +8,7 @@ export const siteConfig: SiteConfig = {
   siteUrl: "https://chae-dahee.vercel.app",
   author: {
     name: "채다희",
-    email: "cdh010126r@gmail.com",
+    email: "chae@dahee.dev",
     twitter: "@Djocken86",
   },
   social: {

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -9,7 +9,7 @@ export const blogInfo: BlogInfo = {
     role: "Frontend Developer",
     bio: "사용자 경험을 중시하는 프론트엔드 개발자입니다. React, Next.js, TypeScript를 주로 다루며, 아름다운 UI와 성능 최적화에 관심이 많습니다.",
     avatar: "/chae-dahee.png",
-    email: "chae-dahee@example.com",
+    email: "chae@dahee.dev",
   },
   social: [
     { name: "GitHub", url: "https://github.com/chae-dahee", icon: "github" },
@@ -19,7 +19,7 @@ export const blogInfo: BlogInfo = {
       icon: "linkedin",
     },
     { name: "Twitter", url: "https://twitter.com/chae-dahee", icon: "twitter" },
-    { name: "Email", url: "mailto:chae-dahee@example.com", icon: "email" },
+    { name: "Email", url: "mailto:chae@dahee.dev", icon: "email" },
   ],
 };
 


### PR DESCRIPTION
## 배경 및 목적

- 블로그 공개 준비의 일환으로 게시글 하단 버튼과 대표 이메일을 정비함
- 공유하기 버튼에 URL 복사 동작을 연결해 방문자가 글을 간편하게 공유할 수 있는 경로를 제공함
- 좋아요 버튼은 저장 백엔드가 없어 동작을 제공할 수 없으므로 제거함
- 프로필과 SEO 설정에 서로 다른 이메일이 사용되고 있어 대표 이메일 `chae@dahee.dev`로 통일함

## 설계

- 공유 기능은 외부 SNS 연동 대신 URL 복사만 구현함
  - 외부 의존성 없이 모든 플랫폼에서 동일하게 동작함
- `PostDetail`은 서버 컴포넌트이므로 클릭 핸들러가 필요한 공유 버튼을 클라이언트 컴포넌트 `ShareButton`으로 분리함
- 좋아요 기능은 별도 저장소 설계가 필요해 이번 범위에서 제외하고 추후 작업으로 검토함

## 구현 내용

- `src/components/blog/ShareButton.tsx` 신규 추가
  - 클릭 시 `navigator.clipboard`로 현재 글 URL 복사
  - 복사 성공 시 2초간 체크 아이콘과 `링크 복사됨` 표시 후 원상 복귀
  - 기존 공유하기 버튼 스타일 유지
- `src/components/blog/PostDetail.tsx` 수정
  - 좋아요 버튼 제거
  - 정적 공유하기 버튼을 `ShareButton`으로 교체
- `src/data/dummyData.ts` 수정
  - 프로필 이메일과 social `mailto:` 링크를 `chae@dahee.dev`로 변경
- `src/config/seo.config.ts` 수정
  - RSS·SEO 작성자 이메일을 `chae@dahee.dev`로 변경

## 코드 리뷰 포인트

- 클립보드 접근 실패 시(비보안 컨텍스트 등) 무시하도록 처리함 — 실패 안내 UI 필요 여부 검토 요청
- `setTimeout` 정리 없이 단순 구현함 — 언마운트 이후 상태 갱신은 React 18에서 경고 없이 무시됨

## 사이드이펙트 검토

- RSS 피드와 SEO 메타의 작성자 이메일이 변경됨
- 게시글 하단에서 좋아요 버튼이 사라짐

- [x] 기존 사용자 breaking 없음 (있다면 마이그레이션 방법 기술)
- [ ] 외부 파일·설정 수정 시 파싱 실패/손실 케이스 처리 — 해당 없음
- [x] 연관 커맨드·스크립트 동작 변화 없음

## 테스트

- `tsc --noEmit` 통과 확인함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 블로그 게시글에 공유 버튼을 추가했습니다.
  - 버튼 클릭 시 공유 링크가 클립보드에 복사됩니다.
  - 복사에 성공하면 버튼 문구/상태가 “링크 복사됨”으로 변경되었다가 자동으로 되돌아옵니다.

- **개선**
  - 기존 좋아요·공유 버튼을 단일 공유 버튼 UI로 통합했습니다.
  - 사이트에 표시되는 작성자 이메일 정보를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->